### PR TITLE
fix cpu-binding both cpuset & cgroup. relate to #1

### DIFF
--- a/exec/bin/burncpu/burncpu.go
+++ b/exec/bin/burncpu/burncpu.go
@@ -28,11 +28,11 @@ import (
 
 	"strconv"
 
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/bin"
+	cl "github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/process"
-	"github.com/chaosblade-io/chaosblade-exec-os/exec/bin"
-	"github.com/chaosblade-io/chaosblade-spec-go/util"
-	cl "github.com/chaosblade-io/chaosblade-spec-go/channel"
 )
 
 var (
@@ -152,7 +152,7 @@ var stopBurnCpuFunc = stopBurnCpu
 
 var runBurnCpuFunc = runBurnCpu
 
-var bindBurnCpuFunc = bindBurnCpu
+var bindBurnCpuFunc = bindBurnCpuByTaskset
 
 var checkBurnCpuFunc = checkBurnCpu
 
@@ -208,8 +208,8 @@ func runBurnCpu(ctx context.Context, cpuCount int, cpuPercent int, pidNeeded boo
 }
 
 // bindBurnCpu by taskset command
-func bindBurnCpu(ctx context.Context, core string, pid int) {
-	response := channel.Run(ctx, "taskset", fmt.Sprintf("-cp %s %d", core, pid))
+func bindBurnCpuByTaskset(ctx context.Context, core string, pid int) {
+	response := channel.Run(ctx, "taskset", fmt.Sprintf("-a -cp %s %d", core, pid))
 	if !response.Success {
 		stopBurnCpuFunc()
 		bin.PrintErrAndExit(response.Err)

--- a/exec/bin/burncpu/burncpu_test.go
+++ b/exec/bin/burncpu/burncpu_test.go
@@ -22,10 +22,10 @@ import (
 	"path"
 	"testing"
 
-	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/bin"
-	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	cl "github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 func Test_startBurnCpu(t *testing.T) {
@@ -113,11 +113,11 @@ func Test_bindBurnCpu(t *testing.T) {
 
 	channel = &cl.MockLocalChannel{
 		Response:         spec.ReturnFail(spec.Code[spec.CommandNotFound], "taskset command not found"),
-		ExpectedCommands: []string{fmt.Sprintf(`taskset -cp 0 25233`)},
+		ExpectedCommands: []string{fmt.Sprintf(`taskset -a -cp 0 25233`)},
 		T:                t,
 	}
 
-	bindBurnCpu(context.Background(), as.core, as.pid)
+	bindBurnCpuByTaskset(context.Background(), as.core, as.pid)
 	if exitCode != 1 {
 		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)
 	}

--- a/exec/bin/burncpu/forlinux/burncpu_test.go
+++ b/exec/bin/burncpu/forlinux/burncpu_test.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/containerd/cgroups"
 
-	"github.com/chaosblade-io/chaosblade-spec-go/spec"
-	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/bin"
 	cl "github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 func Test_startBurnCpu(t *testing.T) {
@@ -45,7 +45,7 @@ func Test_startBurnCpu(t *testing.T) {
 	runBurnCpuFunc = func(ctx context.Context, cpuCount int, pidNeeded bool, processor string) int {
 		return 25233
 	}
-	bindBurnCpuFunc = func(ctx context.Context, core string, pid int) {}
+	bindBurnCpuFunc = func(cgctrl cgroups.Cgroup, cpulist string) {}
 	checkBurnCpuFunc = func(ctx context.Context) {}
 	cgroupNewFunc = func(int, int) cgroups.Cgroup { return new(CgroupMock) }
 	for _, tt := range tests {
@@ -112,11 +112,11 @@ func Test_bindBurnCpu(t *testing.T) {
 
 	channel = &cl.MockLocalChannel{
 		Response:         spec.ReturnFail(spec.Code[spec.CommandNotFound], "taskset command not found"),
-		ExpectedCommands: []string{fmt.Sprintf(`taskset -cp 0 25233`)},
+		ExpectedCommands: []string{fmt.Sprintf(`taskset -a -cp 0 25233`)},
 		T:                t,
 	}
 
-	bindBurnCpu(context.Background(), as.core, as.pid)
+	bindBurnCpuByTaskset(context.Background(), as.core, as.pid)
 	if exitCode != 1 {
 		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
fix cpu bind not correct.

### Does this pull request fix one issue?

Fix #1 

### Describe how you did it

when use taskset for binding cpu :
man taskset:
-a, --all-tasks
              Set or retrieve the CPU affinity of all the tasks (threads) for a given PID.

add -a to taskset command.
```
response := channel.Run(ctx, "taskset", fmt.Sprintf("-a -cp %s %d", core, pid))
```

when use cgorup for binding cpu
update cpuset.cpus to bind:
```
cgctrl.Update(&specs.LinuxResources{CPU: &specs.LinuxCPU{Cpus: cpuList}});
```

### Describe how to verify it
taskset:
pidstat -p $pid 1 

cgroup:
```
cat  /sys/fs/cgroup/cpuset/chaosblade/cpuset.cpus
```
### Special notes for reviews
