### PR TITLE
feature: enhance destroy command

### DIFF
--- a/exec/disk_burn.go
+++ b/exec/disk_burn.go
@@ -50,8 +50,9 @@ func NewBurnActionSpec() spec.ExpActionCommandSpec {
 					Desc: "Block size, MB, default is 10",
 				},
 				&spec.ExpFlag{
-					Name: "path",
-					Desc: "The path of directory where the disk is burning, default value is /",
+					Name:                  "path",
+					Desc:                  "The path of directory where the disk is burning, default value is /",
+					RequiredWhenDestroyed: true,
 				},
 			},
 			ActionExecutor: &BurnIOExecutor{},
@@ -100,6 +101,11 @@ func (be *BurnIOExecutor) Exec(uid string, ctx context.Context, model *spec.ExpM
 	if _, ok := spec.IsDestroy(ctx); ok {
 		readExists := model.ActionFlags["read"] == "true"
 		writeExists := model.ActionFlags["write"] == "true"
+		// set readExists and writeExists to true if does not specify read and write flags
+		if !(readExists || writeExists) {
+			readExists = true
+			writeExists = true
+		}
 		return be.stop(ctx, readExists, writeExists, directory)
 	}
 	if !util.IsDir(directory) {

--- a/exec/network.go
+++ b/exec/network.go
@@ -82,9 +82,10 @@ var commFlags = []spec.ExpFlagSpec{
 		Desc: "destination ip. Support for using mask to specify the ip range, for example, 192.168.1.0/24. You can also use 192.168.1.1 or 192.168.1.1/32 to specify it.",
 	},
 	&spec.ExpFlag{
-		Name:     "interface",
-		Desc:     "Network interface, for example, eth0",
-		Required: true,
+		Name:                  "interface",
+		Desc:                  "Network interface, for example, eth0",
+		Required:              true,
+		RequiredWhenDestroyed: true,
 	},
 }
 

--- a/exec/network_delay.go
+++ b/exec/network_delay.go
@@ -85,21 +85,21 @@ func (de *NetworkDelayExecutor) Exec(uid string, ctx context.Context, model *spe
 	if netInterface == "" {
 		return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less interface parameter")
 	}
-	time := model.ActionFlags["time"]
-	if time == "" {
-		return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less time flag")
-	}
-	offset := model.ActionFlags["offset"]
-	if offset == "" {
-		offset = "10"
-	}
-	localPort := model.ActionFlags["local-port"]
-	remotePort := model.ActionFlags["remote-port"]
-	excludePort := model.ActionFlags["exclude-port"]
-	destIp := model.ActionFlags["destination-ip"]
 	if _, ok := spec.IsDestroy(ctx); ok {
 		return de.stop(netInterface, ctx)
 	} else {
+		time := model.ActionFlags["time"]
+		if time == "" {
+			return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less time flag")
+		}
+		offset := model.ActionFlags["offset"]
+		if offset == "" {
+			offset = "10"
+		}
+		localPort := model.ActionFlags["local-port"]
+		remotePort := model.ActionFlags["remote-port"]
+		excludePort := model.ActionFlags["exclude-port"]
+		destIp := model.ActionFlags["destination-ip"]
 		return de.start(localPort, remotePort, excludePort, destIp, time, offset, netInterface, ctx)
 	}
 }

--- a/exec/network_dns.go
+++ b/exec/network_dns.go
@@ -35,14 +35,16 @@ func NewDnsActionSpec() spec.ExpActionCommandSpec {
 			ActionMatchers: []spec.ExpFlagSpec{},
 			ActionFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
-					Name:     "domain",
-					Desc:     "Domain name",
-					Required: true,
+					Name:                  "domain",
+					Desc:                  "Domain name",
+					Required:              true,
+					RequiredWhenDestroyed: true,
 				},
 				&spec.ExpFlag{
-					Name:     "ip",
-					Desc:     "Domain ip",
-					Required: true,
+					Name:                  "ip",
+					Desc:                  "Domain ip",
+					Required:              true,
+					RequiredWhenDestroyed: true,
 				},
 			},
 			ActionExecutor: &NetworkDnsExecutor{},

--- a/exec/process_stop.go
+++ b/exec/process_stop.go
@@ -35,6 +35,8 @@ func NewStopProcessActionCommandSpec() spec.ExpActionCommandSpec {
 				&spec.ExpFlag{
 					Name: "process",
 					Desc: "Process name",
+					// TODO: Temporarily use this flag as a required parameter for the destroy operation
+					RequiredWhenDestroyed: true,
 				},
 				&spec.ExpFlag{
 					Name: "process-cmd",

--- a/exec/script.go
+++ b/exec/script.go
@@ -35,9 +35,10 @@ func NewScriptCommandModelSpec() spec.ExpModelCommandSpec {
 		spec.BaseExpModelCommandSpec{
 			ExpFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
-					Name:     "file",
-					Desc:     "Script file full path",
-					Required: true,
+					Name:                  "file",
+					Desc:                  "Script file full path",
+					Required:              true,
+					RequiredWhenDestroyed: true,
 				},
 				&spec.ExpFlag{
 					Name:     "function-name",


### PR DESCRIPTION

See chaosblade-io/chaosblade#239 for the deails.

## Describe how you did it
Add `requiredWhenDestroyed` filed in flag which is necessary when destroying.

## Describe how to verify it
Create network experiments to verify with destroy uid and destroy <TARGET> <ACTION> <OPTIONS> commands, for examples:
```
# create command
blade create network delay --time 3000 --interface eth0 --local-port 6379

# destroy command
blade destroy network delay --interface eth0

# create command and return e3a76030daeaebc3 uid
blade create network loss --percent 50 --interface eth0 --local-port 6379

# destroy command
blade destroy e3a76030daeaebc3
```