### PR TITLE
Support percentage of disk size in disk fill experiment

### DIFF
--- a/exec/bin/burncpu/burncpu.go
+++ b/exec/bin/burncpu/burncpu.go
@@ -50,7 +50,7 @@ func main() {
 	flag.IntVar(&cpuCount, "cpu-count", runtime.NumCPU(), "number of cpus")
 	flag.IntVar(&cpuPercent, "cpu-percent", 100, "percent of burn-cpu")
 	flag.StringVar(&cpuProcessor, "cpu-processor", "0", "only used for identifying process of cpu burn")
-	flag.Parse()
+	bin.ParseFlagAndInitLog()
 
 	if cpuCount <= 0 || cpuCount > runtime.NumCPU() {
 		cpuCount = runtime.NumCPU()

--- a/exec/bin/burnio/burnio.go
+++ b/exec/bin/burnio/burnio.go
@@ -43,8 +43,7 @@ func main() {
 	flag.BoolVar(&burnIOStart, "start", false, "start burn io")
 	flag.BoolVar(&burnIOStop, "stop", false, "stop burn io")
 	flag.BoolVar(&burnIONohup, "nohup", false, "start by nohup")
-
-	flag.Parse()
+	bin.ParseFlagAndInitLog()
 
 	if burnIOStart {
 		startBurnIO(burnIODirectory, burnIOSize, burnIORead, burnIOWrite)

--- a/exec/bin/burnmem/burnmem.go
+++ b/exec/bin/burnmem/burnmem.go
@@ -45,7 +45,7 @@ func main() {
 	flag.BoolVar(&burnMemStop, "stop", false, "stop burn memory")
 	flag.BoolVar(&burnMemNohup, "nohup", false, "nohup to run burn memory")
 	flag.IntVar(&memPercent, "mem-percent", 0, "percent of burn memory")
-	flag.Parse()
+	bin.ParseFlagAndInitLog()
 
 	if burnMemStart {
 		startBurnMem()

--- a/exec/bin/changedns/changedns.go
+++ b/exec/bin/changedns/changedns.go
@@ -34,7 +34,7 @@ func main() {
 	flag.StringVar(&dnsIp, "ip", "", "dns ip")
 	flag.BoolVar(&changeDnsStart, "start", false, "start change dns")
 	flag.BoolVar(&changeDnsStop, "stop", false, "recover dns")
-	flag.Parse()
+	bin.ParseFlagAndInitLog()
 
 	if dnsDomain == "" || dnsIp == "" {
 		bin.PrintErrAndExit("less --domain or --ip flag")

--- a/exec/bin/common.go
+++ b/exec/bin/common.go
@@ -17,8 +17,11 @@
 package bin
 
 import (
+	"flag"
 	"fmt"
 	"os"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 const ErrPrefix = "Error:"
@@ -38,4 +41,10 @@ func PrintErrAndExit(message string) {
 func PrintOutputAndExit(message string) {
 	fmt.Fprintf(os.Stdout, message)
 	ExitFunc(0)
+}
+
+func ParseFlagAndInitLog() {
+	util.AddDebugFlag()
+	flag.Parse()
+	util.InitLog(util.Bin)
 }

--- a/exec/bin/delaylossnetwork/delaylossnetwork.go
+++ b/exec/bin/delaylossnetwork/delaylossnetwork.go
@@ -49,9 +49,7 @@ func main() {
 	flag.StringVar(&dlDestinationIp, "destination-ip", "", "destination ip")
 	flag.BoolVar(&dlNetStart, "start", false, "start delay")
 	flag.BoolVar(&dlNetStop, "stop", false, "stop delay")
-	util.AddDebugFlag()
-	flag.Parse()
-	util.InitLog(util.Bin)
+	bin.ParseFlagAndInitLog()
 	if dlNetInterface == "" {
 		bin.PrintErrAndExit("less --interface flag")
 	}

--- a/exec/bin/dropnetwork/dropnetwork.go
+++ b/exec/bin/dropnetwork/dropnetwork.go
@@ -35,7 +35,7 @@ func main() {
 	flag.StringVar(&dropRemotePort, "remote-port", "", "remote port")
 	flag.BoolVar(&dropNetStart, "start", false, "start drop")
 	flag.BoolVar(&dropNetStop, "stop", false, "stop drop")
-	flag.Parse()
+	bin.ParseFlagAndInitLog()
 
 	if dropNetStart == dropNetStop {
 		bin.PrintErrAndExit("must add --start or --stop flag")

--- a/exec/bin/filldisk/filldisk_test.go
+++ b/exec/bin/filldisk/filldisk_test.go
@@ -27,12 +27,14 @@ import (
 
 func Test_startFill_startSuccessful(t *testing.T) {
 	type args struct {
-		path string
-		size string
+		path    string
+		size    string
+		percent string
 	}
 	as := &args{
-		path: "/dev",
-		size: "10",
+		path:    "/dev",
+		size:    "10",
+		percent: "",
 	}
 
 	var exitCode int
@@ -46,7 +48,7 @@ func Test_startFill_startSuccessful(t *testing.T) {
 		T:        t,
 	}
 
-	startFill(as.path, as.size)
+	startFill(as.path, as.size, as.percent)
 	if exitCode != 0 {
 		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)
 	}

--- a/exec/bin/killprocess/killprocess.go
+++ b/exec/bin/killprocess/killprocess.go
@@ -33,8 +33,7 @@ var killProcessInCmd string
 func main() {
 	flag.StringVar(&killProcessName, "process", "", "process name")
 	flag.StringVar(&killProcessInCmd, "process-cmd", "", "process in command")
-
-	flag.Parse()
+	bin.ParseFlagAndInitLog()
 
 	killProcess(killProcessName, killProcessInCmd)
 }

--- a/exec/bin/stopprocess/stopprocess.go
+++ b/exec/bin/stopprocess/stopprocess.go
@@ -37,7 +37,7 @@ func main() {
 	flag.StringVar(&stopProcessInCmd, "process-cmd", "", "process in command")
 	flag.BoolVar(&startFakeDeath, "start", false, "start process fake death")
 	flag.BoolVar(&stopFakeDeath, "stop", false, "recover process fake death")
-	flag.Parse()
+	bin.ParseFlagAndInitLog()
 
 	if startFakeDeath == stopFakeDeath {
 		bin.PrintErrAndExit("must add --start or --stop flag")

--- a/exec/cpu.go
+++ b/exec/cpu.go
@@ -187,7 +187,7 @@ const burnCpuBin = "chaos_burncpu"
 
 // start burn cpu
 func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount int, cpuPercent int) *spec.Response {
-	args := fmt.Sprintf("--start --cpu-count %d --cpu-percent %d", cpuCount, cpuPercent)
+	args := fmt.Sprintf("--start --cpu-count %d --cpu-percent %d --debug=%t", cpuCount, cpuPercent, util.Debug)
 	if cpuList != "" {
 		args = fmt.Sprintf("%s --cpu-list %s", args, cpuList)
 	}
@@ -196,7 +196,8 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount int, 
 
 // stop burn cpu
 func (ce *cpuExecutor) stop(ctx context.Context) *spec.Response {
-	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnCpuBin), "--stop")
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnCpuBin),
+		fmt.Sprintf("--stop --debug=%t", util.Debug))
 }
 
 func checkCpuExpEnv() error {

--- a/exec/disk_burn.go
+++ b/exec/disk_burn.go
@@ -126,12 +126,12 @@ func (be *BurnIOExecutor) Exec(uid string, ctx context.Context, model *spec.ExpM
 
 func (be *BurnIOExecutor) start(ctx context.Context, read, write bool, directory, size string) *spec.Response {
 	return be.channel.Run(ctx, path.Join(be.channel.GetScriptPath(), burnIOBin),
-		fmt.Sprintf("--read=%t --write=%t --directory %s --size %s --start", read, write, directory, size))
+		fmt.Sprintf("--read=%t --write=%t --directory %s --size %s --start --debug=%t", read, write, directory, size, util.Debug))
 }
 
 func (be *BurnIOExecutor) stop(ctx context.Context, read, write bool, directory string) *spec.Response {
 	return be.channel.Run(ctx, path.Join(be.channel.GetScriptPath(), burnIOBin),
-		fmt.Sprintf("--read=%t --write=%t --directory %s --stop", read, write, directory))
+		fmt.Sprintf("--read=%t --write=%t --directory %s --stop --debug=%t", read, write, directory, util.Debug))
 }
 
 func (be *BurnIOExecutor) SetChannel(channel spec.Channel) {

--- a/exec/mem.go
+++ b/exec/mem.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/chaosblade-io/chaosblade-spec-go/channel"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 type MemCommandModelSpec struct {
@@ -145,13 +146,14 @@ const burnMemBin = "chaos_burnmem"
 
 // start burn mem
 func (ce *memExecutor) start(ctx context.Context, memPercent int) *spec.Response {
-	args := fmt.Sprintf("--start --mem-percent %d", memPercent)
+	args := fmt.Sprintf("--start --mem-percent %d --debug=%t", memPercent, util.Debug)
 	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnMemBin), args)
 }
 
 // stop burn mem
 func (ce *memExecutor) stop(ctx context.Context) *spec.Response {
-	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnMemBin), "--stop")
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnMemBin),
+		fmt.Sprintf("--stop --debug=%t", util.Debug))
 }
 
 func checkMemoryExpEnv() error {

--- a/exec/network_dns.go
+++ b/exec/network_dns.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/chaosblade-io/chaosblade-spec-go/channel"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 type DnsActionSpec struct {
@@ -101,12 +102,12 @@ func (ns *NetworkDnsExecutor) Exec(uid string, ctx context.Context, model *spec.
 
 func (ns *NetworkDnsExecutor) start(ctx context.Context, domain, ip string) *spec.Response {
 	return ns.channel.Run(ctx, path.Join(ns.channel.GetScriptPath(), changeDnsBin),
-		fmt.Sprintf("--start --domain %s --ip %s", domain, ip))
+		fmt.Sprintf("--start --domain %s --ip %s --debug=%t", domain, ip, util.Debug))
 }
 
 func (ns *NetworkDnsExecutor) stop(ctx context.Context, domain, ip string) *spec.Response {
 	return ns.channel.Run(ctx, path.Join(ns.channel.GetScriptPath(), changeDnsBin),
-		fmt.Sprintf("--stop --domain %s --ip %s", domain, ip))
+		fmt.Sprintf("--stop --domain %s --ip %s --debug=%t", domain, ip, util.Debug))
 }
 
 func (ns *NetworkDnsExecutor) SetChannel(channel spec.Channel) {

--- a/exec/network_drop.go
+++ b/exec/network_drop.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/chaosblade-io/chaosblade-spec-go/channel"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 type DropActionSpec struct {
@@ -92,7 +93,7 @@ func (ne *NetworkDropExecutor) Exec(suid string, ctx context.Context, model *spe
 }
 
 func (ne *NetworkDropExecutor) start(localPort, remotePort string, ctx context.Context) *spec.Response {
-	args := "--start"
+	args := fmt.Sprintf("--start --debug=%t", util.Debug)
 	if localPort != "" {
 		args = fmt.Sprintf("%s --local-port %s", args, localPort)
 	}
@@ -103,7 +104,7 @@ func (ne *NetworkDropExecutor) start(localPort, remotePort string, ctx context.C
 }
 
 func (ne *NetworkDropExecutor) stop(localPort, remotePort string, ctx context.Context) *spec.Response {
-	args := "--stop"
+	args := fmt.Sprintf("--stop --debug=%t", util.Debug)
 	if localPort != "" {
 		args = fmt.Sprintf("%s --local-port %s", args, localPort)
 	}

--- a/exec/network_loss.go
+++ b/exec/network_loss.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 type LossActionSpec struct {
@@ -99,7 +100,7 @@ func (nle *NetworkLossExecutor) Exec(uid string, ctx context.Context, model *spe
 
 func (nle *NetworkLossExecutor) start(netInterface, localPort, remotePort, excludePort, destIp, percent string,
 	ctx context.Context) *spec.Response {
-	args := fmt.Sprintf("--start --interface %s --percent %s", netInterface, percent)
+	args := fmt.Sprintf("--start --interface %s --percent %s --debug=%t", netInterface, percent, util.Debug)
 	args, err := getCommArgs(localPort, remotePort, excludePort, destIp, args)
 	if err != nil {
 		return spec.ReturnFail(spec.Code[spec.IllegalParameters], err.Error())
@@ -109,7 +110,7 @@ func (nle *NetworkLossExecutor) start(netInterface, localPort, remotePort, exclu
 
 func (nle *NetworkLossExecutor) stop(netInterface string, ctx context.Context) *spec.Response {
 	return nle.channel.Run(ctx, path.Join(nle.channel.GetScriptPath(), dlNetworkBin),
-		fmt.Sprintf("--stop --interface %s", netInterface))
+		fmt.Sprintf("--stop --interface %s --debug=%t", netInterface, util.Debug))
 }
 
 func (nle *NetworkLossExecutor) SetChannel(channel spec.Channel) {

--- a/exec/process_kill.go
+++ b/exec/process_kill.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 type KillProcessActionCommandSpec struct {
@@ -89,11 +90,11 @@ func (kpe *KillProcessExecutor) Exec(uid string, ctx context.Context, model *spe
 	if process == "" && processCmd == "" {
 		return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less process matcher")
 	}
-	flags := ""
+	flags := fmt.Sprintf("--debug=%t", util.Debug)
 	if process != "" {
-		flags = fmt.Sprintf("--process %s", process)
+		flags = fmt.Sprintf("%s --process %s", flags, process)
 	} else if processCmd != "" {
-		flags = fmt.Sprintf("--process-cmd %s", processCmd)
+		flags = fmt.Sprintf("%s --process-cmd %s", flags, processCmd)
 	}
 	return kpe.channel.Run(ctx, path.Join(kpe.channel.GetScriptPath(), killProcessBin), flags)
 }

--- a/exec/process_stop.go
+++ b/exec/process_stop.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
 )
 
 type StopProcessActionCommandSpec struct {
@@ -103,13 +104,13 @@ func (spe *StopProcessExecutor) Exec(uid string, ctx context.Context, model *spe
 }
 
 func (spe *StopProcessExecutor) stopProcess(flags string, ctx context.Context) *spec.Response {
-	args := "--start"
+	args := fmt.Sprintf("--start --debug=%t", util.Debug)
 	flags = fmt.Sprintf("%s %s", args, flags)
 	return spe.channel.Run(ctx, path.Join(spe.channel.GetScriptPath(), stopProcessBin), flags)
 }
 
 func (spe *StopProcessExecutor) recoverProcess(flags string, ctx context.Context) *spec.Response {
-	args := "--stop"
+	args := fmt.Sprintf("--stop --debug=%t", util.Debug)
 	flags = fmt.Sprintf("%s %s", args, flags)
 	return spe.channel.Run(ctx, path.Join(spe.channel.GetScriptPath(), stopProcessBin), flags)
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
It is easier to specify the disk size 

### Does this pull request fix one issue?
chaosblade-io/chaosblade#241
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Add percent flag in disk fill experiment.
2. If both size and percent flags are present, the percent flag is preferred.
3. Calculate disk usage and compare to the percent value. If the current disk usage greater than the percent, the blade returns error. Otherwise, subtractusage from the value of percent and multiply the total disk size to get the desired value.

### Describe how to verify it
`blade c disk fill --percent 60 --path /home/admin`


### Special notes for reviews
