### PR TITLE
feature: add rate and mode flags for mem load experiment

### DIFF
--- a/exec/bin/burnmem/burnmem_test.go
+++ b/exec/bin/burnmem/burnmem_test.go
@@ -36,7 +36,7 @@ func Test_startBurnMem(t *testing.T) {
 		exitCode = code
 	}
 
-	runBurnMemFunc = func(context.Context, int) int {
+	runBurnMemFunc = func(context.Context, int, int, int, string) int {
 		return 1
 	}
 
@@ -60,7 +60,10 @@ func Test_startBurnMem(t *testing.T) {
 
 func Test_runBurnMem_failed(t *testing.T) {
 	type args struct {
-		memPercent int
+		memPercent  int
+		memReserve  int
+		memRate     int
+		burnMemMode string
 	}
 	as := &args{
 		memPercent: 50,
@@ -82,7 +85,7 @@ func Test_runBurnMem_failed(t *testing.T) {
 		return true, ""
 	}
 
-	runBurnMem(context.Background(), as.memPercent)
+	runBurnMem(context.Background(), as.memPercent, as.memReserve, as.memRate, as.burnMemMode)
 
 	if exitCode != 1 {
 		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it  
support cache and ram mode for mem load experiment

### Does this pull request fix one issue?
Fixes:  https://github.com/chaosblade-io/chaosblade/issues/278
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. add --rate and --mode flags for mem load experiment
2. use buff chan to fill the mem with golang

### Describe how to verify it


### Special notes for reviews
