### PR TITLE
bugxif: fix buff chan size to support large memory machine

### DIFF
--- a/exec/bin/burnmem/burnmem.go
+++ b/exec/bin/burnmem/burnmem.go
@@ -101,7 +101,7 @@ func burnMemWithRam() {
 	if err != nil {
 		bin.PrintErrAndExit(err.Error())
 	}
-	buffChan := make(chan Block, int(total*1024/32))
+	buffChan := make(chan Block, total*1024/32)
 	defer close(buffChan)
 	for {
 		t := time.NewTicker(1 * time.Second)
@@ -112,7 +112,7 @@ func burnMemWithRam() {
 				bin.PrintErrAndExit(err.Error())
 			}
 			if expectMem > 0 {
-				if expectMem > int64(memRate) {
+				if expectMem > int64(memRate) && memRate > 0 {
 					fillBuffChan(int64(memRate), buffChan)
 				} else {
 					fillBuffChan(expectMem, buffChan)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
1. change buff chan size to int64
2. make ram mode still works if `--rate` flags is not defined

### Does this pull request fix one issue?
Fixs: https://github.com/chaosblade-io/chaosblade/issues/285

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
