### PR TITLE
feature: support network packets duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ pre_build:
 build_yaml: build/spec.go
 	$(GO) run $< $(OS_YAML_FILE_PATH)
 
-build_osbin: build_burncpu build_burnmem build_burnio build_killprocess build_stopprocess build_changedns build_dlnetwork build_dropnetwork build_filldisk
+build_osbin: build_burncpu build_burnmem build_burnio build_killprocess build_stopprocess build_changedns build_tcnetwork build_dropnetwork build_filldisk
 
 build_osbin_darwin: build_burncpu build_killprocess build_stopprocess build_changedns
 
@@ -67,8 +67,8 @@ build_stopprocess: exec/bin/stopprocess/stopprocess.go
 build_changedns: exec/bin/changedns/changedns.go
 	$(GO) build $(GO_FLAGS) -o $(BUILD_TARGET_BIN)/chaos_changedns $<
 
-build_dlnetwork: exec/bin/delaylossnetwork/delaylossnetwork.go
-	$(GO) build $(GO_FLAGS) -o $(BUILD_TARGET_BIN)/chaos_dlnetwork $<
+build_tcnetwork: exec/bin/tcnetwork/tcnetwork.go
+	$(GO) build $(GO_FLAGS) -o $(BUILD_TARGET_BIN)/chaos_tcnetwork $<
 
 build_dropnetwork: exec/bin/dropnetwork/dropnetwork.go
 	$(GO) build $(GO_FLAGS) -o $(BUILD_TARGET_BIN)/chaos_dropnetwork $<

--- a/exec/bin/tcnetwork/tcnetwork_test.go
+++ b/exec/bin/tcnetwork/tcnetwork_test.go
@@ -206,3 +206,38 @@ func Test_addQdiscForDelay(t *testing.T) {
 		t.Errorf("unexpected result: %d, expected result: %d", exitCode, 1)
 	}
 }
+
+func Test_startDuplicateNet(t *testing.T) {
+	type args struct {
+		netInterface string
+		classRule    string
+		localPort    string
+		remotePort   string
+		excludePort  string
+		destIp       string
+	}
+
+	as := &args{
+		netInterface: "eth0",
+		classRule:    "netem duplicate 50%",
+		localPort:    "",
+		remotePort:   "",
+		excludePort:  "",
+	}
+
+	var exitCode int
+	bin.ExitFunc = func(code int) {
+		exitCode = code
+	}
+	channel = &channel2.MockLocalChannel{
+		Response: spec.ReturnSuccess("success"),
+		ExpectedCommands: []string{
+			`ifconfig eth0 txqueuelen 1000`,
+			`tc qdisc add dev eth0 root netem duplicate 50%`},
+		T: t,
+	}
+	startNet(as.netInterface, as.classRule, as.localPort, as.remotePort, as.excludePort, as.destIp)
+	if exitCode != 0 {
+		t.Errorf("unexpected result: %d, expected result: %d", exitCode, 1)
+	}
+}

--- a/exec/network.go
+++ b/exec/network.go
@@ -37,6 +37,7 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				NewDropActionSpec(),
 				NewDnsActionSpec(),
 				NewLossActionSpec(),
+				NewDuplicateActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},
@@ -61,8 +62,8 @@ func (*NetworkCommandSpec) Example() string {
 # You can execute "blade query network interface" command to query the interfaces`
 }
 
-// dlNetworkBin for delay and loss experiments
-var dlNetworkBin = "chaos_dlnetwork"
+// tcNetworkBin for network delay, loss, duplicate, reorder and corrupt experiments
+var tcNetworkBin = "chaos_tcnetwork"
 
 var commFlags = []spec.ExpFlagSpec{
 	&spec.ExpFlag{

--- a/exec/network_loss.go
+++ b/exec/network_loss.go
@@ -84,12 +84,12 @@ func (nle *NetworkLossExecutor) Exec(uid string, ctx context.Context, model *spe
 		}
 		dev = netInterface
 	}
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return nle.stop(dev, ctx)
+	}
 	percent := model.ActionFlags["percent"]
 	if percent == "" {
 		return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less percent flag")
-	}
-	if _, ok := spec.IsDestroy(ctx); ok {
-		return nle.stop(dev, ctx)
 	}
 	localPort := model.ActionFlags["local-port"]
 	remotePort := model.ActionFlags["remote-port"]
@@ -101,17 +101,17 @@ func (nle *NetworkLossExecutor) Exec(uid string, ctx context.Context, model *spe
 
 func (nle *NetworkLossExecutor) start(netInterface, localPort, remotePort, excludePort, destIp, percent string,
 	ignorePeerPort bool, ctx context.Context) *spec.Response {
-	args := fmt.Sprintf("--start --interface %s --percent %s --debug=%t", netInterface, percent, util.Debug)
+	args := fmt.Sprintf("--start --type loss --interface %s --percent %s --debug=%t", netInterface, percent, util.Debug)
 	args, err := getCommArgs(localPort, remotePort, excludePort, destIp, args, ignorePeerPort)
 	if err != nil {
 		return spec.ReturnFail(spec.Code[spec.IllegalParameters], err.Error())
 	}
-	return nle.channel.Run(ctx, path.Join(nle.channel.GetScriptPath(), dlNetworkBin), args)
+	return nle.channel.Run(ctx, path.Join(nle.channel.GetScriptPath(), tcNetworkBin), args)
 }
 
 func (nle *NetworkLossExecutor) stop(netInterface string, ctx context.Context) *spec.Response {
-	return nle.channel.Run(ctx, path.Join(nle.channel.GetScriptPath(), dlNetworkBin),
-		fmt.Sprintf("--stop --interface %s --debug=%t", netInterface, util.Debug))
+	return nle.channel.Run(ctx, path.Join(nle.channel.GetScriptPath(), tcNetworkBin),
+		fmt.Sprintf("--stop --type loss --interface %s --debug=%t", netInterface, util.Debug))
 }
 
 func (nle *NetworkLossExecutor) SetChannel(channel spec.Channel) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See chaosblade-io/chaosblade#292

### Describe how you did it
1. Add network duplication action.
2. Modify the original `dlnetwork` directory and file to `tcnetwork` to support more network chaos experiments, such as packet duplication, package re-ordering and packet corruption.

### Describe how to verify it
Execute the following command to cause 50 percent packets duplication when request the 80 remote port :
```
blade c network duplicate  --percent 50 --interface eth0 --remote-port 80 --debug
```
Use `tcpdump` command to capture communication data on remote port 80 to record test-chaosblade-duplicate-80.pcap file:
```
tcpdump -vv -tttt -S -i eth0 -s 0 -w test-chaosblade-duplicate-80.pcap dst host 180.101.49.11 and port 80
```
Request the remote http service:
```
curl 180.101.49.11
```
Download the test-chaosblade-duplicate-80.pcap file and opened with wireshark app:
![image](https://user-images.githubusercontent.com/3992234/72680127-435e3c00-3af1-11ea-8f95-8ca73c7690f4.png)


### Special notes for reviews
