### PR TITLE
feature: add network packet re-ordering and corruption

### DIFF
--- a/exec/bin/tcnetwork/tcnetwork.go
+++ b/exec/bin/tcnetwork/tcnetwork.go
@@ -37,6 +37,8 @@ var netPercent, delayNetTime, delayNetOffset string
 var tcNetStart, tcNetStop bool
 var tcIgnorePeerPorts bool
 var actionType string
+var reorderGap string
+var correlation string
 
 const delimiter = ","
 const (
@@ -60,6 +62,8 @@ func main() {
 	flag.BoolVar(&tcNetStop, "stop", false, "stop delay")
 	flag.BoolVar(&tcIgnorePeerPorts, "ignore-peer-port", false, "ignore excluding all ports communicating with this port, generally used when the ss command does not exist")
 	flag.StringVar(&actionType, "type", "", "network experiment type, value is delay|loss|duplicate|corrupt|reorder, required")
+	flag.StringVar(&reorderGap, "gap", "", "packets gap")
+	flag.StringVar(&correlation, "correlation", "0", "correlation on previous packet")
 	bin.ParseFlagAndInitLog()
 
 	if tcNetInterface == "" {
@@ -75,6 +79,14 @@ func main() {
 			classRule = fmt.Sprintf("netem loss %s%%", netPercent)
 		case Duplicate:
 			classRule = fmt.Sprintf("netem duplicate %s%%", netPercent)
+		case Corrupt:
+			classRule = fmt.Sprintf("netem corrupt %s%%", netPercent)
+		case Reorder:
+			classRule = fmt.Sprintf("netem reorder %s%% %s%%", netPercent, correlation)
+			if reorderGap != "" {
+				classRule = fmt.Sprintf("%s gap %s", classRule, reorderGap)
+			}
+			classRule = fmt.Sprintf("%s delay %sms", classRule, delayNetTime)
 		default:
 			bin.PrintErrAndExit("unsupported type for network experiments")
 		}

--- a/exec/network.go
+++ b/exec/network.go
@@ -38,6 +38,8 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				NewDnsActionSpec(),
 				NewLossActionSpec(),
 				NewDuplicateActionSpec(),
+				NewCorruptActionSpec(),
+				NewReorderActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/network_corrupt.go
+++ b/exec/network_corrupt.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+)
+
+type CorruptActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewCorruptActionSpec() spec.ExpActionCommandSpec {
+	return &CorruptActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: commFlags,
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "percent",
+					Desc:     "Corruption percent, must be positive integer without %, for example, --percent 50",
+					Required: true,
+				},
+			},
+			ActionExecutor: &NetworkCorruptExecutor{},
+		},
+	}
+}
+
+func (*CorruptActionSpec) Name() string {
+	return "corrupt"
+}
+
+func (*CorruptActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*CorruptActionSpec) ShortDesc() string {
+	return "Corrupt experiment"
+}
+
+func (*CorruptActionSpec) LongDesc() string {
+	return "Corrupt experiment"
+}
+
+type NetworkCorruptExecutor struct {
+	channel spec.Channel
+}
+
+func (ce *NetworkCorruptExecutor) Name() string {
+	return "corrupt"
+}
+
+func (ce *NetworkCorruptExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	err := checkNetworkExpEnv()
+	if err != nil {
+		return spec.ReturnFail(spec.Code[spec.CommandNotFound], err.Error())
+	}
+	if ce.channel == nil {
+		return spec.ReturnFail(spec.Code[spec.ServerError], "channel is nil")
+	}
+	netInterface := model.ActionFlags["interface"]
+	if netInterface == "" {
+		return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less interface parameter")
+	}
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return ce.stop(netInterface, ctx)
+	} else {
+		percent := model.ActionFlags["percent"]
+		if percent == "" {
+			return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less percent flag")
+		}
+		localPort := model.ActionFlags["local-port"]
+		remotePort := model.ActionFlags["remote-port"]
+		excludePort := model.ActionFlags["exclude-port"]
+		destIp := model.ActionFlags["destination-ip"]
+		ignorePeerPort := model.ActionFlags["ignore-peer-port"] == "true"
+		return ce.start(netInterface, localPort, remotePort, excludePort, destIp, percent, ignorePeerPort, ctx)
+	}
+}
+
+func (ce *NetworkCorruptExecutor) start(netInterface, localPort, remotePort, excludePort, destIp, percent string,
+	ignorePeerPort bool, ctx context.Context) *spec.Response {
+	args := fmt.Sprintf("--start --type corrupt --interface %s --percent %s --debug=%t", netInterface, percent, util.Debug)
+	args, err := getCommArgs(localPort, remotePort, excludePort, destIp, args, ignorePeerPort)
+	if err != nil {
+		return spec.ReturnFail(spec.Code[spec.IllegalParameters], err.Error())
+	}
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), tcNetworkBin), args)
+}
+
+func (ce *NetworkCorruptExecutor) stop(netInterface string, ctx context.Context) *spec.Response {
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), tcNetworkBin),
+		fmt.Sprintf("--stop --type corrupt --interface %s --debug=%t", netInterface, util.Debug))
+}
+
+func (ce *NetworkCorruptExecutor) SetChannel(channel spec.Channel) {
+	ce.channel = channel
+}

--- a/exec/network_reorder.go
+++ b/exec/network_reorder.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+)
+
+type ReorderActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewReorderActionSpec() spec.ExpActionCommandSpec {
+	return &ReorderActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: commFlags,
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "percent",
+					Desc:     "Packets are sent immediately percentage, must be positive integer without %, for example, --percent 50",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "correlation",
+					Desc:     "Correlation on previous packet, value is between 0 and 100",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "gap",
+					Desc:     "Packet gap, must be positive integer",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "time",
+					Desc:     "Delay time, must be positive integer, unit is millisecond, default value is 10",
+					Required: false,
+				},
+			},
+			ActionExecutor: &NetworkReorderExecutor{},
+		},
+	}
+}
+
+func (*ReorderActionSpec) Name() string {
+	return "reorder"
+}
+
+func (*ReorderActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*ReorderActionSpec) ShortDesc() string {
+	return "Reorder experiment"
+}
+
+func (*ReorderActionSpec) LongDesc() string {
+	return "Reorder experiment"
+}
+
+type NetworkReorderExecutor struct {
+	channel spec.Channel
+}
+
+func (ce *NetworkReorderExecutor) Name() string {
+	return "recorder"
+}
+
+func (ce *NetworkReorderExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	err := checkNetworkExpEnv()
+	if err != nil {
+		return spec.ReturnFail(spec.Code[spec.CommandNotFound], err.Error())
+	}
+	if ce.channel == nil {
+		return spec.ReturnFail(spec.Code[spec.ServerError], "channel is nil")
+	}
+	netInterface := model.ActionFlags["interface"]
+	if netInterface == "" {
+		return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less interface parameter")
+	}
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return ce.stop(netInterface, ctx)
+	} else {
+		percent := model.ActionFlags["percent"]
+		if percent == "" {
+			return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less percent flag")
+		}
+		gap := model.ActionFlags["gap"]
+		time := model.ActionFlags["time"]
+		if time == "" {
+			time = "10"
+		}
+		correlation := model.ActionFlags["correlation"]
+		if correlation == "" {
+			correlation = "0"
+		}
+		localPort := model.ActionFlags["local-port"]
+		remotePort := model.ActionFlags["remote-port"]
+		excludePort := model.ActionFlags["exclude-port"]
+		destIp := model.ActionFlags["destination-ip"]
+		ignorePeerPort := model.ActionFlags["ignore-peer-port"] == "true"
+		return ce.start(netInterface, localPort, remotePort, excludePort, destIp, percent,
+			ignorePeerPort, gap, time, correlation, ctx)
+	}
+}
+
+func (ce *NetworkReorderExecutor) start(netInterface, localPort, remotePort, excludePort, destIp, percent string,
+	ignorePeerPort bool, gap, time, correlation string, ctx context.Context) *spec.Response {
+	args := fmt.Sprintf("--start --type reorder --interface %s --percent %s --correlation %s --time %s --debug=%t",
+		netInterface, percent, correlation, time, util.Debug)
+	if gap != "" {
+		args = fmt.Sprintf("%s --gap %s", args, gap)
+	}
+	args, err := getCommArgs(localPort, remotePort, excludePort, destIp, args, ignorePeerPort)
+	if err != nil {
+		return spec.ReturnFail(spec.Code[spec.IllegalParameters], err.Error())
+	}
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), tcNetworkBin), args)
+}
+
+func (ce *NetworkReorderExecutor) stop(netInterface string, ctx context.Context) *spec.Response {
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), tcNetworkBin),
+		fmt.Sprintf("--stop --type reorder --interface %s --debug=%t", netInterface, util.Debug))
+}
+
+func (ce *NetworkReorderExecutor) SetChannel(channel spec.Channel) {
+	ce.channel = channel
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See chaosblade-io/chaosblade#293

### Describe how you did it
1. Add `reorder` action contains `percent`, `correlation`, `gap` and `time` flags.
2. Add `corrupt` action contains `percent` flag.

### Describe how to verify it
Execute the following command to verify reorder:
```
blade c network reorder --percent 75 --correlation 50 --destination-ip 100.xxx.xxx.xxx  --interface eth0 --time 1200
```
Use `ping 100.xxx.xxx.xxx -A` to verify:
![image](https://user-images.githubusercontent.com/3992234/72778458-078fb780-3c54-11ea-8b16-b645cf963d81.png)
![image](https://user-images.githubusercontent.com/3992234/72778500-1b3b1e00-3c54-11ea-963b-f991cc4da43b.png)

Execute the following command to verify corrupt:
```
blade c network corrupt --percent 75 --interface eth0 --destination-ip 100.xx.xx.xx
```
Use `ping 100.xxx.xxx.xxx -A` to verify:
![image](https://user-images.githubusercontent.com/3992234/72779015-994bf480-3c55-11ea-8c45-2a559d01961e.png)

