### PR TITLE
bugfix: fix simulation of memory usage experiment using ram mode

### DIFF
--- a/exec/bin/burnio/burnio.go
+++ b/exec/bin/burnio/burnio.go
@@ -143,9 +143,9 @@ func burnWrite(directory, size string) {
 
 // read burn
 func burnRead(directory, size string) {
-	// create a 1g file under the directory
+	// create a 600M file under the directory
 	tmpFileForRead := path.Join(directory, readFile)
-	createArgs := fmt.Sprintf("if=/dev/zero of=%s bs=%sM count=%d oflag=dsync", tmpFileForRead, size, count)
+	createArgs := fmt.Sprintf("if=/dev/zero of=%s bs=%dM count=%d oflag=dsync", tmpFileForRead, 6, count)
 	response := channel.Run(context.TODO(), "dd", createArgs)
 	if !response.Success {
 		bin.PrintAndExitWithErrPrefix(

--- a/exec/bin/burnmem/burnmem_test.go
+++ b/exec/bin/burnmem/burnmem_test.go
@@ -36,8 +36,7 @@ func Test_startBurnMem(t *testing.T) {
 		exitCode = code
 	}
 
-	runBurnMemFunc = func(context.Context, int, int, int, string) int {
-		return 1
+	runBurnMemFunc = func(context.Context, int, int, int, string) {
 	}
 
 	stopBurnMemFunc = func() (bool, string) {

--- a/exec/disk_fill.go
+++ b/exec/disk_fill.go
@@ -51,7 +51,7 @@ func NewFillActionSpec() spec.ExpActionCommandSpec {
 				},
 				&spec.ExpFlag{
 					Name: "reserve",
-					Desc: "Disk reserve size, unit is MB. The value is a positive integer without unit. If size, percent and reserve flags exit, the priority is as follows: percent > reserve > size",
+					Desc: "Disk reserve size, unit is MB. The value is a positive integer without unit. If size, percent and reserve flags exist, the priority is as follows: percent > reserve > size",
 				},
 			},
 			ActionExecutor: &FillActionExecutor{},


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See #18 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Cache objects with map and slice.
2. If the memory to be occupied is less than the value of `rate`, apply for 10% of the memory with expect occupation each time. Default rate is 100M/S. You can use `--rate` to specify the value.
3. If the size of the slice during expansion(cap * 1.25) is greater than the size of the memory to be occupied, a new slice is created and cached in the map.

### Describe how to verify it
```
blade create mem load --mode ram --mem-percent 90 --rate 10
```


### Special notes for reviews
