### PR TITLE
Adapt to centos6 for memory experiments and adjust cache mode…

### DIFF
--- a/exec/mem.go
+++ b/exec/mem.go
@@ -134,7 +134,7 @@ func (ce *memExecutor) Exec(uid string, ctx context.Context, model *spec.ExpMode
 		return spec.ReturnFail(spec.Code[spec.ServerError], "channel is nil")
 	}
 	if _, ok := spec.IsDestroy(ctx); ok {
-		return ce.stop(ctx)
+		return ce.stop(ctx, model.ActionFlags["mode"])
 	}
 	var memPercent, memReserve, memRate int
 
@@ -187,9 +187,9 @@ func (ce *memExecutor) start(ctx context.Context, memPercent, memReserve, memRat
 }
 
 // stop burn mem
-func (ce *memExecutor) stop(ctx context.Context) *spec.Response {
+func (ce *memExecutor) stop(ctx context.Context, burnMemMode string) *spec.Response {
 	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnMemBin),
-		fmt.Sprintf("--stop --debug=%t", util.Debug))
+		fmt.Sprintf("--stop --mode %s --debug=%t", burnMemMode, util.Debug))
 }
 
 func checkMemoryExpEnv() error {

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20200110072855-4f767ce4e582
 github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20200110072855-4f767ce4e582/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.0 h1:IcacKph5X7rgAA0d8d4Myh0ko3blXWKBg4jWnA4mH+E=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.0/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
+github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb h1:rAeJAuxWeKF6rOVmch7QTNno7FkN8cWhoC+MRZ6qE9I=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
 github.com/containerd/cgroups v0.0.0-20191011165608-5fbad35c2a7e h1:3bt+8T1I/CuYx+a5ww32+UT4fc9x8iRiXrhfduFTlBU=
 github.com/containerd/cgroups v0.0.0-20191011165608-5fbad35c2a7e/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=


### PR DESCRIPTION
… logic

Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See chaosblade-io/chaosblade#303

### Describe how you did it
1. Modify the logic of obtaining memory information from cgroup.
2. Change PAGE_COUNTER_MAX value to adapt centos6.
3. Delete the cache mode to dynamically adjust memory usage, and add parameter support later.

### Describe how to verify it
Run it on centos6 machine and container.

### Special notes for reviews
