### PR TITLE
feature: remove unnecessary flag when destroying

### DIFF
--- a/exec/disk_burn.go
+++ b/exec/disk_burn.go
@@ -50,9 +50,8 @@ func NewBurnActionSpec() spec.ExpActionCommandSpec {
 					Desc: "Block size, MB, default is 10",
 				},
 				&spec.ExpFlag{
-					Name:                  "path",
-					Desc:                  "The path of directory where the disk is burning, default value is /",
-					RequiredWhenDestroyed: true,
+					Name: "path",
+					Desc: "The path of directory where the disk is burning, default value is /",
 				},
 			},
 			ActionExecutor: &BurnIOExecutor{},

--- a/exec/disk_fill.go
+++ b/exec/disk_fill.go
@@ -35,9 +35,8 @@ func NewFillActionSpec() spec.ExpActionCommandSpec {
 		spec.BaseExpActionCommandSpec{
 			ActionMatchers: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
-					Name:                  "path",
-					Desc:                  "The path of directory where the disk is populated, default value is /",
-					RequiredWhenDestroyed: true,
+					Name: "path",
+					Desc: "The path of directory where the disk is populated, default value is /",
 				},
 			},
 			ActionFlags: []spec.ExpFlagSpec{

--- a/exec/process_stop.go
+++ b/exec/process_stop.go
@@ -36,8 +36,6 @@ func NewStopProcessActionCommandSpec() spec.ExpActionCommandSpec {
 				&spec.ExpFlag{
 					Name: "process",
 					Desc: "Process name",
-					// TODO: Temporarily use this flag as a required parameter for the destroy operation
-					RequiredWhenDestroyed: true,
 				},
 				&spec.ExpFlag{
 					Name: "process-cmd",


### PR DESCRIPTION
Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See chaosblade-io/chaosblade#324 for the details.

### Describe how you did it
Delete unnecessary `requiredWhenDestroyed` flag.

### Describe how to verify it
```
blade c network delay --time 3000 --interface eth0 --remote-port 80
blade d network delay --time 3000 --interface eth0 --remote-port 80
```

### Special notes for reviews
