### PR TITLE
feature: add retain-handle flag in disk fill experiment

### DIFF
--- a/exec/bin/filldisk/filldisk.go
+++ b/exec/bin/filldisk/filldisk.go
@@ -21,12 +21,14 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"os"
 	"path"
 	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	"github.com/sirupsen/logrus"
 
@@ -34,55 +36,113 @@ import (
 )
 
 var fillDataFile = "chaos_filldisk.log.dat"
-var fillDiskSize, fillDiskDirectory, fillDiskPercent, ReserveDiskSize string
-var fillDiskStart, fillDiskStop bool
+var fillDiskSize, fillDiskDirectory, fillDiskPercent, reserveDiskSize string
+var fillDiskStart, fillDiskStop, fillDiskRetainHandle, fillDiskRetainNohup bool
 
 const diskFillErrorMessage = "No space left on device"
 
 func main() {
 	flag.StringVar(&fillDiskDirectory, "directory", "", "the directory where the disk is populated")
 	flag.StringVar(&fillDiskSize, "size", "", "fill size, unit is M")
-	flag.StringVar(&ReserveDiskSize, "reserve", "", "reserve size, unit is M")
+	flag.StringVar(&reserveDiskSize, "reserve", "", "reserve size, unit is M")
 	flag.StringVar(&fillDiskPercent, "percent", "", "percentage of disk, positive integer without %")
 	flag.BoolVar(&fillDiskStart, "start", false, "start fill or not")
 	flag.BoolVar(&fillDiskStop, "stop", false, "stop fill or not")
+	flag.BoolVar(&fillDiskRetainHandle, "retain-handle", false, "whether to retain the big file handle")
+	flag.BoolVar(&fillDiskRetainNohup, "retain-nohup", false, "whether to read the big file in the background")
 	bin.ParseFlagAndInitLog()
 
 	if fillDiskStart == fillDiskStop {
 		bin.PrintErrAndExit("must specify start or stop operation")
 	}
+
 	if fillDiskStart {
-		startFill(fillDiskDirectory, fillDiskSize, fillDiskPercent, ReserveDiskSize)
-	} else if fillDiskStop {
-		stopFill(fillDiskDirectory)
-	} else {
-		bin.PrintErrAndExit("less --start or --stop flag")
+		if fillDiskRetainHandle && fillDiskRetainNohup {
+			if err := retainFileHandle(); err != nil {
+				bin.PrintErrAndExit(err.Error())
+			}
+		}
+		err, result := startFill(fillDiskDirectory, fillDiskSize, fillDiskPercent, reserveDiskSize, fillDiskRetainHandle)
+		if err != nil {
+			bin.PrintErrAndExit(err.Error())
+		}
+		bin.PrintOutputAndExit(result)
 	}
+	if fillDiskStop {
+		if err := stopFill(fillDiskDirectory); err != nil {
+			bin.PrintErrAndExit(err.Error())
+		}
+	}
+}
+
+// retainFileHandle by opening the file
+func retainFileHandle() error {
+	// open the temp file to retain file handle
+	dataFilePath := path.Join(fillDiskDirectory, fillDataFile)
+	file, err := os.Open(dataFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s file, %s", dataFilePath, err.Error())
+	}
+	defer file.Close()
+	select {}
 }
 
 var cl = channel.NewLocalChannel()
 
-func startFill(directory, size, percent, reserve string) {
+func startFill(directory, size, percent, reserve string, retainHandle bool) (error, string) {
 	ctx := context.TODO()
 	if directory == "" {
-		bin.PrintErrAndExit("--directory flag value is empty")
+		return fmt.Errorf("--directory flag value is empty"), ""
 	}
 	if size == "" && percent == "" && reserve == "" {
-		bin.PrintErrAndExit("less --size or --percent or --reserve  flag")
+		return fmt.Errorf("less --size or --percent or --reserve flag"), ""
 	}
 	dataFile := path.Join(directory, fillDataFile)
-	// calculate the fill size
 	size, err := calculateFileSize(directory, size, percent, reserve)
 	if err != nil {
-		bin.PrintErrAndExit(fmt.Sprintf("calculate size err, %v", err))
+		return fmt.Errorf("calculate size err, %v", err), ""
 	}
-
+	var response *spec.Response
 	// Some normal filesystems (ext4, xfs, btrfs and ocfs2) tack quick works
 	if cl.IsCommandAvailable("fallocate") {
-		fillDiskByFallocate(ctx, size, dataFile)
+		response = fillDiskByFallocate(ctx, size, dataFile)
 	}
-	// If execute fallocate command failed, use dd command to retry.
-	fillDiskByDD(ctx, dataFile, directory, size)
+	if response == nil || !response.Success {
+		// If execute fallocate command failed, use dd command to retry.
+		response = fillDiskByDD(ctx, dataFile, directory, size)
+	}
+	if response.Success {
+		if retainHandle {
+			// start a process to hold the file handle
+			resp := startRetainProcess(ctx, directory)
+			if !resp.Success {
+				logrus.Warningf("failed to start retain process, %s", resp.Err)
+			}
+		}
+		return nil, response.Result.(string)
+	}
+	if err = stopFill(directory); err != nil {
+		logrus.Warningf("failed to stop fill when starting failed, %v, starting err: %s", err, response.Err)
+	}
+	return fmt.Errorf(response.Err), ""
+}
+
+var fillDiskBin = "chaos_filldisk"
+
+func startRetainProcess(ctx context.Context, directory string) *spec.Response {
+	logFile, err := util.GetLogFile(util.Bin)
+	if err != nil {
+		logFile = "/dev/null"
+	}
+	args := fmt.Sprintf(`%s --start --retain-handle --retain-nohup --directory %s >> %s 2>&1 &`,
+		path.Join(util.GetProgramPath(), fillDiskBin), directory, logFile)
+	return cl.Run(ctx, "nohup", args)
+}
+
+var getSysStatFunc = func(directory string) *syscall.Statfs_t {
+	var stat syscall.Statfs_t
+	syscall.Statfs(directory, &stat)
+	return &stat
 }
 
 // calculateFileSize returns the size which should be filled, unit is M
@@ -90,9 +150,7 @@ func calculateFileSize(directory, size, percent, reserve string) (string, error)
 	if percent == "" && reserve == "" {
 		return size, nil
 	}
-
-	var stat syscall.Statfs_t
-	syscall.Statfs(directory, &stat)
+	stat := getSysStatFunc(directory)
 	allBytes := stat.Blocks * uint64(stat.Bsize)
 	availableBytes := stat.Bavail * uint64(stat.Bsize)
 	usedBytes := allBytes - availableBytes
@@ -102,10 +160,8 @@ func calculateFileSize(directory, size, percent, reserve string) (string, error)
 		if err != nil {
 			return "", err
 		}
-
 		usedPercentage, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(usedBytes)/float64(allBytes)), 64)
 		expectedPercentage, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(p)/100.0), 64)
-
 		if usedPercentage >= expectedPercentage {
 			return "", fmt.Errorf("the disk has been used %.2f, large than expected", usedPercentage)
 		}
@@ -118,7 +174,6 @@ func calculateFileSize(directory, size, percent, reserve string) (string, error)
 		if err != nil {
 			return "", err
 		}
-
 		availableMB := float64(availableBytes) / (1024.0 * 1024.0)
 		if availableMB <= r {
 			return "", fmt.Errorf("the disk has available size %.2f, less than expected", availableMB)
@@ -128,41 +183,44 @@ func calculateFileSize(directory, size, percent, reserve string) (string, error)
 	}
 }
 
-func fillDiskByFallocate(ctx context.Context, size string, dataFile string) {
+func fillDiskByFallocate(ctx context.Context, size string, dataFile string) *spec.Response {
 	response := cl.Run(ctx, "fallocate", fmt.Sprintf(`-l %sM %s`, size, dataFile))
 	if response.Success {
-		bin.PrintOutputAndExit(response.Result.(string))
+		return response
 	}
 	// Need to judge that the disk is full or not. If the disk is full, return success
 	if strings.Contains(response.Err, diskFillErrorMessage) {
-		bin.PrintOutputAndExit(fmt.Sprintf("success because of %s", diskFillErrorMessage))
+		return spec.ReturnSuccess(fmt.Sprintf("success because of %s", diskFillErrorMessage))
 	}
 	logrus.Warningf("execute fallocate err, %s", response.Err)
+	return spec.ReturnFail(spec.Code[spec.ExecCommandError], fmt.Sprintf("execute fallocate err, %s", response.Err))
 }
 
-func fillDiskByDD(ctx context.Context, dataFile string, directory string, size string) {
+func fillDiskByDD(ctx context.Context, dataFile string, directory string, size string) *spec.Response {
 	// Because of filling disk slowly using dd, so execute dd with 1b size first to test the command.
 	response := cl.Run(ctx, "dd", fmt.Sprintf(`if=/dev/zero of=%s bs=1b count=1 iflag=fullblock`, dataFile))
 	if !response.Success {
-		stopFill(directory)
-		bin.PrintErrAndExit(response.Err)
+		return response
 	}
 	response = cl.Run(ctx, "nohup",
 		fmt.Sprintf(`dd if=/dev/zero of=%s bs=1M count=%s iflag=fullblock >/dev/null 2>&1 &`, dataFile, size))
-	if !response.Success {
-		stopFill(directory)
-		bin.PrintErrAndExit(response.Err)
-	}
-	bin.PrintOutputAndExit(response.Result.(string))
+	return response
 }
 
 // stopFill contains kill the filldisk process and delete the temp file actions
-func stopFill(directory string) {
+func stopFill(directory string) error {
 	ctx := context.Background()
 	if directory == "" {
-		bin.PrintErrAndExit("--directory flag value is empty")
+		return fmt.Errorf("--directory flag value is empty")
 	}
+	// kill dd or fallocate process
 	pids, _ := cl.GetPidsByProcessName(fillDataFile, ctx)
+	if pids != nil || len(pids) >= 0 {
+		cl.Run(ctx, "kill", fmt.Sprintf("-9 %s", strings.Join(pids, " ")))
+	}
+	// kill daemon process
+	ctx = context.WithValue(ctx, channel.ProcessKey, fillDiskBin)
+	pids, _ = cl.GetPidsByProcessName("retain-nohup", ctx)
 	if pids != nil || len(pids) >= 0 {
 		cl.Run(ctx, "kill", fmt.Sprintf("-9 %s", strings.Join(pids, " ")))
 	}
@@ -170,7 +228,8 @@ func stopFill(directory string) {
 	if util.IsExist(fileName) {
 		response := cl.Run(ctx, "rm", fmt.Sprintf(`-rf %s`, fileName))
 		if !response.Success {
-			bin.PrintErrAndExit(response.Err)
+			return fmt.Errorf(response.Err)
 		}
 	}
+	return nil
 }

--- a/exec/bin/filldisk/filldisk_test.go
+++ b/exec/bin/filldisk/filldisk_test.go
@@ -18,64 +18,203 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"syscall"
 	"testing"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/channel"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
-
-	"github.com/chaosblade-io/chaosblade-exec-os/exec/bin"
 )
 
-func Test_startFill_startSuccessful(t *testing.T) {
+func Test_startFill(t *testing.T) {
 	type args struct {
-		path    string
-		size    string
-		percent string
-		reserve string
+		directory    string
+		size         string
+		percent      string
+		reserve      string
+		retainHandle bool
 	}
-	as := &args{
-		path:    "/dev",
-		size:    "10",
-		percent: "",
-		reserve: "",
+	tests := []struct {
+		name   string
+		args   args
+		err    error
+		result string
+	}{
+		{
+			name: "directory value is empty",
+			args: args{"", "", "", "", false},
+			err:  fmt.Errorf("--directory flag value is empty"),
+		},
+		{
+			name: "size,percent and reserve values are empty",
+			args: args{"/dev", "", "", "", false},
+			err:  fmt.Errorf("less --size or --percent or --reserve flag"),
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err, result := startFill(tt.args.directory, tt.args.size, tt.args.percent, tt.args.reserve, tt.args.retainHandle)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("startFill() got = %v, want %v", err, tt.err)
+			}
+			if result != tt.result {
+				t.Errorf("startFill() got1 = %v, want %v", result, tt.result)
+			}
+		})
+	}
+}
 
-	var exitCode int
-	bin.ExitFunc = func(code int) {
-		exitCode = code
+func Test_calculateFileSize(t *testing.T) {
+	// mock sys stat
+	getSysStatFunc = func(directory string) *syscall.Statfs_t {
+		return &syscall.Statfs_t{
+			Blocks: 10287952,
+			Bavail: 6735107,
+			Bsize:  4096,
+			Bfree:  7263465,
+		}
 	}
+	allBytes := 10287952 * 4096
+	availableBytes := 6735107 * 4096
+	usedBytes := allBytes - availableBytes
+	usedPercentage, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(usedBytes)/float64(allBytes)), 64)
+	expectedPercentage, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(50)/100.0), 64)
+	remainderPercentage := expectedPercentage - usedPercentage
+	expectSizeForPercent := math.Floor(remainderPercentage * float64(allBytes) / (1024.0 * 1024.0))
 
-	cl = channel.NewMockLocalChannel()
-	mockChannel := cl.(*channel.MockLocalChannel)
-	mockChannel.RunFunc = func(ctx context.Context, script, args string) *spec.Response {
-		return spec.ReturnSuccess("success")
+	availableMB := float64(availableBytes) / (1024.0 * 1024.0)
+	expectSizeForReserve := math.Floor(availableMB - 1024)
+
+	type args struct {
+		directory string
+		size      string
+		percent   string
+		reserve   string
 	}
-
-	startFill(as.path, as.size, as.percent, as.reserve)
-	if exitCode != 0 {
-		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)
+	tests := []struct {
+		name         string
+		args         args
+		expectedSize string
+		wantErr      bool
+	}{
+		{
+			name: "size is 40G, percent is empty, reserve is empty",
+			args: args{
+				directory: "/",
+				size:      "40960",
+				percent:   "",
+				reserve:   "",
+			},
+			expectedSize: "40960",
+			wantErr:      false,
+		},
+		{
+			name: "size is empty, percent is 50, reserve is 1024",
+			args: args{
+				directory: "/",
+				size:      "",
+				percent:   "50",
+				reserve:   "1024",
+			},
+			expectedSize: fmt.Sprintf("%.f", expectSizeForPercent),
+			wantErr:      false,
+		},
+		{
+			name: "size is empty, percent is 20 less than used, reserve is 1024",
+			args: args{
+				directory: "/",
+				size:      "",
+				percent:   "20",
+				reserve:   "1024",
+			},
+			expectedSize: "",
+			wantErr:      true,
+		},
+		{
+			name: "size is empty, percent is empty, reserve is 1024",
+			args: args{
+				directory: "/",
+				size:      "",
+				percent:   "",
+				reserve:   "1024",
+			},
+			expectedSize: fmt.Sprintf("%.f", expectSizeForReserve),
+			wantErr:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedSize, err := calculateFileSize(tt.args.directory, tt.args.size, tt.args.percent, tt.args.reserve)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("calculateFileSize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if expectedSize != tt.expectedSize {
+				t.Errorf("calculateFileSize() got = %v, want %v", expectedSize, tt.expectedSize)
+			}
+		})
 	}
 }
 
 func Test_stopFill(t *testing.T) {
-	cl = channel.NewMockLocalChannel()
-	mockChannel := cl.(*channel.MockLocalChannel)
-	mockChannel.RunFunc = func(ctx context.Context, script, args string) *spec.Response {
-		return spec.ReturnSuccess("success")
+	processMap := map[string]struct{}{
+		"1": {},
+		"2": {},
 	}
-	bin.ExitFunc = func(code int) {}
+	cl = &channel.MockLocalChannel{
+		RunFunc: func(ctx context.Context, script, args string) *spec.Response {
+			if script == "kill" {
+				if args == "-9 1" {
+					delete(processMap, "1")
+				}
+				if args == "-9 2" {
+					delete(processMap, "2")
+				}
+			} else {
+				t.Errorf("stopFill() error, not invoking kill command")
+			}
+			return nil
+		},
+		GetPidsByProcessNameFunc: func(processName string, ctx context.Context) ([]string, error) {
+			if processName == fillDataFile {
+				return []string{"1"}, nil
+			}
+			if processName == "retain-nohup" {
+				return []string{"2"}, nil
+			}
+			return []string{}, nil
+		},
+	}
 	type args struct {
-		mountPoint string
+		directory string
 	}
 	tests := []struct {
-		name string
-		args args
+		name    string
+		args    args
+		wantErr bool
 	}{
-		{"stop", args{"/dev"}},
+		{
+			name:    "directory is empty",
+			args:    args{""},
+			wantErr: true,
+		},
+		{
+			name:    "directory is /",
+			args:    args{"/"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stopFill(tt.args.mountPoint)
+			if err := stopFill(tt.args.directory); (err != nil) != tt.wantErr {
+				t.Errorf("stopFill() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
+	}
+	if len(processMap) != 0 {
+		t.Errorf("stopFill() error, does not kill necessary process")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb
+	github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413053019-c6149ff993b4
 	github.com/containerd/cgroups v0.0.0-20191011165608-5fbad35c2a7e
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2-0.20190716192640-c9a5f6194441

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb h1:rAeJAuxWeKF6rOVmch7QTNno7FkN8cWhoC+MRZ6qE9I=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
+github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413053019-c6149ff993b4 h1:vIn/uqBty/+xv7Tei5cdjrpfuXpNTO6l37zNl3lPPuw=
+github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413053019-c6149ff993b4/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
 github.com/containerd/cgroups v0.0.0-20191011165608-5fbad35c2a7e h1:3bt+8T1I/CuYx+a5ww32+UT4fc9x8iRiXrhfduFTlBU=
 github.com/containerd/cgroups v0.0.0-20191011165608-5fbad35c2a7e/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=


### PR DESCRIPTION
Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
chaosblade-io/chaosblade#325

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add `retain-handle` flag to hold the file handle.

### Describe how to verify it
```
blade c disk fill --retain-handle --percent 50
```
Use lsof command to lookup file handle:
```
 lsof | grep chaos_filldisk.log.dat
chaos_fil 26833          root    3r      REG              253,1 6320816128         18 /chaos_filldisk.log.dat
chaos_fil 26833 26834    root    3r      REG              253,1 6320816128         18 /chaos_filldisk.log.dat
chaos_fil 26833 26835    root    3r      REG              253,1 6320816128         18 /chaos_filldisk.log.dat
chaos_fil 26833 26836    root    3r      REG              253,1 6320816128         18 /chaos_filldisk.log.dat
chaos_fil 26833 26838    root    3r      REG              253,1 6320816128         18 /chaos_filldisk.log.dat
```

### Special notes for reviews
