### PR TITLE
add caught interrupt supprot for graceful exiting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 2
+
+[Dockerfile]
+indent_style = tab
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[.travis.yml]
+indent_style = space
+indent_size = 2
+
+[*.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

add caught interrupt supprot for graceful exiting

### Does this pull request fix one issue?

The `kill -9 <pid>`  command is kill process by OS that will be caught resources (eg memory, disk read handler..) not recycle not immediately. So `kill -HUP` is good choice to exiting or stop process more graceful. see more https://en.wikipedia.org/wiki/Kill_(command).

btw: I consider directory `forlinux` maybe duplicate?
