### PR TITLE
feature:add --exclude-buffer-cache flag for mem experiment ram model

### DIFF
--- a/exec/bin/burnmem/burnmem.go
+++ b/exec/bin/burnmem/burnmem.go
@@ -44,15 +44,16 @@ const PAGE_COUNTER_MAX uint64 = 9223372036854770000
 type Block [32 * 1024]int32
 
 var (
-	burnMemStart, burnMemStop, burnMemNohup bool
-	memPercent, memReserve, memRate         int
-	burnMemMode                             string
+	burnMemStart, burnMemStop, burnMemNohup, excludeBufferCache bool
+	memPercent, memReserve, memRate                             int
+	burnMemMode                                                 string
 )
 
 func main() {
 	flag.BoolVar(&burnMemStart, "start", false, "start burn memory")
 	flag.BoolVar(&burnMemStop, "stop", false, "stop burn memory")
 	flag.BoolVar(&burnMemNohup, "nohup", false, "nohup to run burn memory")
+	flag.BoolVar(&excludeBufferCache, "exclude-buffer-cache", false, "ram model mem-percent is exclude buffer/cache")
 	flag.IntVar(&memPercent, "mem-percent", 0, "percent of burn memory")
 	flag.IntVar(&memReserve, "reserve", 0, "reserve to burn memory, unit is M")
 	flag.IntVar(&memRate, "rate", 100, "burn memory rate, unit is M/S, only support for ram mode")
@@ -170,12 +171,12 @@ func startBurnMem() {
 			bin.PrintErrAndExit(response.Error())
 		}
 	}
-	runBurnMemFunc(ctx, memPercent, memReserve, memRate, burnMemMode)
+	runBurnMemFunc(ctx, memPercent, memReserve, memRate, burnMemMode, excludeBufferCache)
 }
 
-func runBurnMem(ctx context.Context, memPercent, memReserve, memRate int, burnMemMode string) {
-	args := fmt.Sprintf(`%s --nohup --mem-percent %d --reserve %d --rate %d --mode %s`,
-		path.Join(util.GetProgramPath(), burnMemBin), memPercent, memReserve, memRate, burnMemMode)
+func runBurnMem(ctx context.Context, memPercent, memReserve, memRate int, burnMemMode string, excludeBufferCache bool) {
+	args := fmt.Sprintf(`%s --nohup --mem-percent %d --reserve %d --rate %d --mode %s --exclude-buffer-cache=%t`,
+		path.Join(util.GetProgramPath(), burnMemBin), memPercent, memReserve, memRate, burnMemMode, excludeBufferCache)
 	args = fmt.Sprintf(`%s > /dev/null 2>&1 &`, args)
 	response := cl.Run(ctx, "nohup", args)
 	if !response.Success {
@@ -242,6 +243,8 @@ func calculateMemSize(percent, reserve int) (int64, int64, error) {
 		available = int64(virtualMemory.Available)
 		if burnMemMode == "cache" {
 			available = int64(virtualMemory.Free)
+		} else if burnMemMode == "ram" && excludeBufferCache {
+			available = total - int64(virtualMemory.Used)
 		}
 	} else {
 		total = int64(memoryStat.Usage.Limit)


### PR DESCRIPTION
Signed-off-by: tiny.x <185120555@qq.com>

### Describe what this PR does / why we need it
`./blade c mem load --mode ram --mem-percent 50 `

Most of the monitoring percentage calculations do not include buffer/cache, resulting in memory experiments not meeting the monitored warning indicators

### Describe how to verify it
`./blade c mem load --mode ram --mem-percent 50 --exclude-buffer-cache`
