### PR TITLE
add cpu climb time feature

### DIFF
--- a/exec/bin/burnmem/burnmem.go
+++ b/exec/bin/burnmem/burnmem.go
@@ -44,15 +44,16 @@ const PAGE_COUNTER_MAX uint64 = 9223372036854770000
 type Block [32 * 1024]int32
 
 var (
-	burnMemStart, burnMemStop, burnMemNohup bool
-	memPercent, memReserve, memRate         int
-	burnMemMode                             string
+	burnMemStart, burnMemStop, burnMemNohup, excludeBufferCache bool
+	memPercent, memReserve, memRate                             int
+	burnMemMode                                                 string
 )
 
 func main() {
 	flag.BoolVar(&burnMemStart, "start", false, "start burn memory")
 	flag.BoolVar(&burnMemStop, "stop", false, "stop burn memory")
 	flag.BoolVar(&burnMemNohup, "nohup", false, "nohup to run burn memory")
+	flag.BoolVar(&excludeBufferCache, "exclude-buffer-cache", false, "ram model mem-percent is exclude buffer/cache")
 	flag.IntVar(&memPercent, "mem-percent", 0, "percent of burn memory")
 	flag.IntVar(&memReserve, "reserve", 0, "reserve to burn memory, unit is M")
 	flag.IntVar(&memRate, "rate", 100, "burn memory rate, unit is M/S, only support for ram mode")
@@ -170,12 +171,12 @@ func startBurnMem() {
 			bin.PrintErrAndExit(response.Error())
 		}
 	}
-	runBurnMemFunc(ctx, memPercent, memReserve, memRate, burnMemMode)
+	runBurnMemFunc(ctx, memPercent, memReserve, memRate, burnMemMode, excludeBufferCache)
 }
 
-func runBurnMem(ctx context.Context, memPercent, memReserve, memRate int, burnMemMode string) {
-	args := fmt.Sprintf(`%s --nohup --mem-percent %d --reserve %d --rate %d --mode %s`,
-		path.Join(util.GetProgramPath(), burnMemBin), memPercent, memReserve, memRate, burnMemMode)
+func runBurnMem(ctx context.Context, memPercent, memReserve, memRate int, burnMemMode string, excludeBufferCache bool) {
+	args := fmt.Sprintf(`%s --nohup --mem-percent %d --reserve %d --rate %d --mode %s --exclude-buffer-cache=%t`,
+		path.Join(util.GetProgramPath(), burnMemBin), memPercent, memReserve, memRate, burnMemMode, excludeBufferCache)
 	args = fmt.Sprintf(`%s > /dev/null 2>&1 &`, args)
 	response := cl.Run(ctx, "nohup", args)
 	if !response.Success {
@@ -242,6 +243,8 @@ func calculateMemSize(percent, reserve int) (int64, int64, error) {
 		available = int64(virtualMemory.Available)
 		if burnMemMode == "cache" {
 			available = int64(virtualMemory.Free)
+		} else if burnMemMode == "ram" && excludeBufferCache {
+			available = total - int64(virtualMemory.Used)
 		}
 	} else {
 		total = int64(memoryStat.Usage.Limit)

--- a/exec/cpu.go
+++ b/exec/cpu.go
@@ -149,7 +149,7 @@ func (ce *cpuExecutor) Exec(uid string, ctx context.Context, model *spec.ExpMode
 		}
 		if cpuPercent > 100 || cpuPercent < 0 {
 			return spec.ReturnFail(spec.Code[spec.IllegalParameters],
-				fmt.Sprintf("--cpu-percent value must be a prositive integer and not bigger than 100!"))
+				"--cpu-percent value must be a prositive integer and not bigger than 100!")
 		}
 	} else {
 		cpuPercent = 100

--- a/exec/cpu.go
+++ b/exec/cpu.go
@@ -61,6 +61,11 @@ func NewCpuCommandModelSpec() spec.ExpModelCommandSpec {
 					Desc:     "percent of burn CPU (0-100)",
 					Required: false,
 				},
+				&spec.ExpFlag{
+					Name:     "climb-time",
+					Desc:     "durations(s) to climb",
+					Required: false,
+				},
 			},
 		},
 	}
@@ -79,7 +84,7 @@ func (*CpuCommandModelSpec) LongDesc() string {
 }
 
 func (*CpuCommandModelSpec) Example() string {
-	return "blade create cpu load --cpu-percent 80"
+	return "blade create cpu load --cpu-percent 80 --climb-time 60"
 }
 
 type fullLoadActionCommand struct {
@@ -132,6 +137,7 @@ func (ce *cpuExecutor) Exec(uid string, ctx context.Context, model *spec.ExpMode
 	var cpuCount int
 	var cpuList string
 	var cpuPercent int
+	var climbTime int
 
 	cpuPercentStr := model.ActionFlags["cpu-percent"]
 	if cpuPercentStr != "" {
@@ -143,7 +149,7 @@ func (ce *cpuExecutor) Exec(uid string, ctx context.Context, model *spec.ExpMode
 		}
 		if cpuPercent > 100 || cpuPercent < 0 {
 			return spec.ReturnFail(spec.Code[spec.IllegalParameters],
-				"--cpu-percent value must be a prositive integer and not bigger than 100")
+				fmt.Sprintf("--cpu-percent value must be a prositive integer and not bigger than 100!"))
 		}
 	} else {
 		cpuPercent = 100
@@ -176,14 +182,29 @@ func (ce *cpuExecutor) Exec(uid string, ctx context.Context, model *spec.ExpMode
 			cpuCount = runtime.NumCPU()
 		}
 	}
-	return ce.start(ctx, cpuList, cpuCount, cpuPercent)
+
+	climbTimeStr := model.ActionFlags["climb-time"]
+	if climbTimeStr != "" {
+		var err error
+		climbTime, err = strconv.Atoi(climbTimeStr)
+		if err != nil {
+			return spec.ReturnFail(spec.Code[spec.IllegalParameters],
+				"--climb-time value must be a positive integer")
+		}
+		if climbTime > 600 || climbTime < 0 {
+			return spec.ReturnFail(spec.Code[spec.IllegalParameters],
+				"--climb-time value must be a prositive integer and not bigger than 600")
+		}
+	}
+
+	return ce.start(ctx, cpuList, cpuCount, cpuPercent, climbTime)
 }
 
 const burnCpuBin = "chaos_burncpu"
 
 // start burn cpu
-func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount int, cpuPercent int) *spec.Response {
-	args := fmt.Sprintf("--start --cpu-count %d --cpu-percent %d --debug=%t", cpuCount, cpuPercent, util.Debug)
+func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount int, cpuPercent int, climbTime int) *spec.Response {
+	args := fmt.Sprintf("--start --climb-time %d --cpu-count %d --cpu-percent %d --debug=%t", climbTime, cpuCount, cpuPercent, util.Debug)
 	if cpuList != "" {
 		args = fmt.Sprintf("%s --cpu-list %s", args, cpuList)
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
make CPU slowly climb to some level, to simulate slow resource competition which system faults cannot be quickly noticed by monitoring system

### Describe how you did it
add a ticker to control cpuPercent

### Describe how to verify it
```bash 
./chaos_burncpu  -nohup -cpu-percent 80 -climb-time 120
```
![image](https://user-images.githubusercontent.com/25023285/88197207-b8fbbe00-cc74-11ea-93ad-c5727fe93745.png)

