### PR TITLE
bugfix: fix stopping disk io burning failed

### DIFF
--- a/exec/bin/burnio/burnio.go
+++ b/exec/bin/burnio/burnio.go
@@ -98,7 +98,7 @@ func startBurnIO(directory, size string, read, write bool) {
 
 // stop burn io,  no need to add os.Exit
 func stopBurnIO(directory string, read, write bool) {
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), channel.ExcludeProcessKey, "--stop")
 	if read {
 		// dd process
 		pids, _ := cl.GetPidsByProcessName(readFile, ctx)


### PR DESCRIPTION
Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Bugfix.
`Signal killed` returned when the disk burn scenario is destroying.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Exclude keyword of destroying process.

### Describe how to verify it
Package and test it.

### Special notes for reviews
