### PR TITLE
feature: add ignore-not-found flag in process experiments

### DIFF
--- a/exec/bin/killprocess/killProcess_test.go
+++ b/exec/bin/killprocess/killProcess_test.go
@@ -74,7 +74,7 @@ func Test_killProcess(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			killProcess(tt.args.process, tt.args.processCmd, tt.args.localPorts, tt.args.count)
+			killProcess(tt.args.process, tt.args.processCmd, tt.args.localPorts, "9", "", tt.args.count, false)
 			if tt.exitCode != exitCode {
 				t.Errorf("unexpected exitCode %d, expected exitCode: %d", exitCode, tt.exitCode)
 			}

--- a/exec/bin/killprocess/killprocess.go
+++ b/exec/bin/killprocess/killprocess.go
@@ -30,6 +30,7 @@ import (
 
 var killProcessName, killProcessInCmd, killProcessLocalPorts, killProcessSignal, killProcessExcludeProcess string
 var killProcessCount int
+var ignoreProcessNotFound bool
 
 func main() {
 	flag.StringVar(&killProcessName, "process", "", "process name")
@@ -38,14 +39,16 @@ func main() {
 	flag.StringVar(&killProcessLocalPorts, "local-port", "", "local service ports")
 	flag.StringVar(&killProcessSignal, "signal", "9", "kill process signal")
 	flag.StringVar(&killProcessExcludeProcess, "exclude-process", "", "kill process exclude specific process")
+	flag.BoolVar(&ignoreProcessNotFound, "ignore-not-found", false, "ignore process that can't be found")
 	bin.ParseFlagAndInitLog()
 
-	killProcess(killProcessName, killProcessInCmd, killProcessLocalPorts, killProcessSignal, killProcessExcludeProcess, killProcessCount)
+	killProcess(killProcessName, killProcessInCmd, killProcessLocalPorts, killProcessSignal, killProcessExcludeProcess,
+		killProcessCount, ignoreProcessNotFound)
 }
 
 var cl = channel.NewLocalChannel()
 
-func killProcess(process, processCmd, localPorts, signal, excludeProcess string, count int) {
+func killProcess(process, processCmd, localPorts, signal, excludeProcess string, count int, ignoreProcessNotFound bool) {
 	var pids []string
 	var err error
 	var excludeProcessValue = fmt.Sprintf("blade,%s", excludeProcess)
@@ -73,6 +76,10 @@ func killProcess(process, processCmd, localPorts, signal, excludeProcess string,
 		}
 	}
 	if pids == nil || len(pids) == 0 {
+		if ignoreProcessNotFound {
+			bin.PrintOutputAndExit("process not found")
+			return
+		}
 		bin.PrintErrAndExit(fmt.Sprintf("%s process not found", killProcessName))
 		return
 	}

--- a/exec/process.go
+++ b/exec/process.go
@@ -27,7 +27,13 @@ type ProcessCommandModelSpec struct {
 func NewProcessCommandModelSpec() spec.ExpModelCommandSpec {
 	return &ProcessCommandModelSpec{
 		spec.BaseExpModelCommandSpec{
-			ExpFlags: []spec.ExpFlagSpec{},
+			ExpFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:   "ignore-not-found",
+					Desc:   "Ignore process that cannot be found",
+					NoArgs: true,
+				},
+			},
 			ExpActions: []spec.ExpActionCommandSpec{
 				NewKillProcessActionCommandSpec(),
 				NewStopProcessActionCommandSpec(),

--- a/exec/process_kill.go
+++ b/exec/process_kill.go
@@ -71,7 +71,10 @@ blade create process kill --process SimpleHTTPServer
 blade create process kill --process-cmd java
 
 # Specifies the semaphore and local port to kill the process
-blade c process kill --local-port 8080 --signal 15`,
+blade c process kill --local-port 8080 --signal 15
+
+# Return success even if the process not found
+blade c process kill --process demo --ignore-not-found`,
 			ActionPrograms: []string{KillProcessBin},
 		},
 	}
@@ -117,6 +120,7 @@ func (kpe *KillProcessExecutor) Exec(uid string, ctx context.Context, model *spe
 	localPorts := model.ActionFlags["local-port"]
 	signal := model.ActionFlags["signal"]
 	excludeProcess := model.ActionFlags["exclude-process"]
+	ignoreProcessNotFound := model.ActionFlags["ignore-not-found"] == "true"
 	if process == "" && processCmd == "" && localPorts == "" {
 		return spec.ReturnFail(spec.Code[spec.IllegalParameters], "less process matcher")
 	}
@@ -140,6 +144,9 @@ func (kpe *KillProcessExecutor) Exec(uid string, ctx context.Context, model *spe
 	}
 	if excludeProcess != "" {
 		flags = fmt.Sprintf(`%s --exclude-process %s`, flags, excludeProcess)
+	}
+	if ignoreProcessNotFound {
+		flags = fmt.Sprintf(`%s --ignore-not-found=%t`, flags, ignoreProcessNotFound)
 	}
 	return kpe.channel.Run(ctx, path.Join(kpe.channel.GetScriptPath(), KillProcessBin), flags)
 }


### PR DESCRIPTION
Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Sometimes it is expected that the process does not exist.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add `--ignore-not-found` flag in process scenarios.

### Describe how to verify it
```
blade c process kill --process tomcat --ignore-not-found
```
### Special notes for reviews
