### PR TITLE
bugfix: fix using both exclude-port and exclude-ip flags

### DIFF
--- a/exec/bin/tcnetwork/tcnetwork.go
+++ b/exec/bin/tcnetwork/tcnetwork.go
@@ -132,19 +132,6 @@ func startNet(netInterface, classRule, localPort, remotePort, excludePort, destI
 	}
 	response = addQdiscForDL(cl, ctx, netInterface)
 
-	// only contains excludePort or excludeIP
-	if localPort == "" && remotePort == "" && destIp == "" {
-		args := buildNetemToDefaultBandsArgs(netInterface, classRule)
-		excludeFilters := buildExcludeFilterToNewBand(netInterface, excludePort, excludeIp)
-		response := cl.Run(ctx, "tc", args+excludeFilters)
-		if !response.Success {
-			stopDLNetFunc(netInterface)
-			bin.PrintErrAndExit(response.Err)
-		}
-		bin.PrintOutputAndExit(response.Result.(string))
-		return
-	}
-
 	var excludePorts []string
 	if excludePort != "" {
 		excludePorts, err = getExcludePorts(excludePort)
@@ -152,6 +139,20 @@ func startNet(netInterface, classRule, localPort, remotePort, excludePort, destI
 			stopDLNetFunc(netInterface)
 			bin.PrintErrAndExit(response.Err)
 		}
+	}
+
+	// only contains excludePort or excludeIP
+	if localPort == "" && remotePort == "" && destIp == "" {
+		// Add class rule to 1,2,3 band, exclude port and exclude ip are added to 4 band
+		args := buildNetemToDefaultBandsArgs(netInterface, classRule)
+		excludeFilters := buildExcludeFilterToNewBand(netInterface, excludePorts, excludeIp)
+		response := cl.Run(ctx, "tc", args+excludeFilters)
+		if !response.Success {
+			stopDLNetFunc(netInterface)
+			bin.PrintErrAndExit(response.Err)
+		}
+		bin.PrintOutputAndExit(response.Result.(string))
+		return
 	}
 	destIpRules := getIpRules(destIp)
 	excludeIpRules := getIpRules(excludeIp)
@@ -193,42 +194,19 @@ func getExcludePorts(excludePort string) ([]string, error) {
 	return excludePorts, nil
 }
 
-func buildExcludeFilterToNewBand(netInterface string, excludePort string, excludeIp string) string {
-	var ports []string
+func buildExcludeFilterToNewBand(netInterface string, excludePorts []string, excludeIp string) string {
 	var args string
-	if excludePort != "" {
-		ports = strings.Split(excludePort, delimiter)
+	excludeIpRules := getIpRules(excludeIp)
+	for _, rule := range excludeIpRules {
+		args = fmt.Sprintf(
+			`%s && \
+			tc filter add dev %s parent 1: prio 4 protocol ip u32 %s flowid 1:4`,
+			args, netInterface, rule)
 	}
-	ipRules := getIpRules(excludeIp)
-	if len(ports) == 0 {
-		for _, ip := range ipRules {
-			if strings.TrimSpace(ip) == "" {
-				continue
-			}
-			args = fmt.Sprintf(
-				`%s && \
-			tc filter add dev %s parent 1: prio 4 protocol ip u32 match ip dst %s flowid 1:4`,
-				args, netInterface, ip)
-		}
-		return args
-	}
-	for _, port := range ports {
+
+	for _, port := range excludePorts {
 		if strings.TrimSpace(port) == "" {
 			continue
-		}
-		//
-		if len(ipRules) > 0 {
-			for _, ip := range ipRules {
-				if strings.TrimSpace(ip) == "" {
-					continue
-				}
-				args = fmt.Sprintf(
-					`%s && \
-			tc filter add dev %s parent 1: prio 4 protocol ip u32 %s match ip sport %s 0xffff flowid 1:4 && \,
-			tc filter add dev %s parent 1: prio 4 protocol ip u32 %s match ip dport %s 0xffff flowid 1:4`,
-					args, netInterface, ip, port, netInterface, ip, port)
-			}
-			return args
 		}
 		args = fmt.Sprintf(
 			`%s && \
@@ -249,6 +227,7 @@ func buildNetemToDefaultBandsArgs(netInterface, classRule string) string {
 	return args
 }
 
+// Reserved for the peer server ips of the command channel
 func readServerIps() ([]string, error) {
 	ips := make([]string, 0)
 	return ips, nil
@@ -293,6 +272,9 @@ func getIpRules(targetIp string) []string {
 	ips := strings.Split(ipString, delimiter)
 	ipRules := make([]string, 0)
 	for _, ip := range ips {
+		if strings.TrimSpace(ip) == "" {
+			continue
+		}
 		ipRules = append(ipRules, fmt.Sprintf("match ip dst %s", ip))
 	}
 	return ipRules


### PR DESCRIPTION
Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Does this pull request fix one issue?
chaosblade-io/chaosblade#453

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

I expect that when the exclude-port and exclude-ip flags are used at the same time, the exclude-port and exclude-ip flags take effect separately instead of being combined together like ip:port.

For example, --exclude-ip 1.1.1.1 --exclude-port 80 flags exclude 1.1.1.1 and 80 instead of 1.1.1.1:80

### Describe how to verify it

1. When `local-port` or `remote-port` is used with `destination-ip`, the `destination-ip:local-port` or `destination-ip:remote-port` takes effect. For example:
```
# blade c network loss --percent 100 --timeout 60 --interface eth0 --remote-port 80,443 --destination-ip 61.155.221.xxx
{"code":200,"success":true,"result":"d605e9999397ac82"}

# ping 61.155.221.xxx
PING 61.155.221.xxx (61.155.221.xxx) 56(84) bytes of data.
64 bytes from 61.155.221.xxx: icmp_seq=1 ttl=53 time=14.6 ms
--- 61.155.221.xxx ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 14.603/14.603/14.603/0.000 ms

# telnet 61.155.221.xxx 80
Trying 61.155.221.xxx...
```

2. When `local-port` or `remote-port` is used with `exclude-ip`, the all of `exclude-ip` ports don't take effect, only other ips with `local-port`or `remote-port` take effect. For example:
```
blade c network loss --percent 100 --timeout 60 --interface eth0 --remote-port 80,443 --exclude-ip 61.155.221.xxx,180.101.49.xxx
{"code":200,"success":true,"result":"7ce80f937a0b3342"}

# ping www.xxx.com
PING img2x-sched.xxx-cdn.com (180.97.189.xxx) 56(84) bytes of data.
64 bytes from 180.97.189.xxx (180.97.189.xxx): icmp_seq=1 ttl=52 time=15.5 ms
--- img2x-sched.xxx-cdn.com ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 6ms
rtt min/avg/max/mdev = 14.731/15.010/15.541/0.400 ms

# telnet 180.97.189.xxx 80
Trying 180.97.189.xxx...
^C
# telnet 61.155.221.xxx 80
Trying 61.155.221.xxx...
Connected to 61.155.221.xxx.
Escape character is '^]'.
^CConnection closed by foreign host.

# telnet 180.101.49.xxx 80
Trying 180.101.49.xxx...
Connected to 180.101.49.xxx.
Escape character is '^]'.
```

3. When `local-port` or `remote-port` is used with `exclude-port`, the `exclude-port` doesn't take effect, the `local-port` or `remote-port` takes effect. For example:
```
blade c network loss --percent 100 --timeout 60 --interface eth0 --remote-port 400-500 --exclude-port 80
{"code":200,"success":true,"result":"2032f3d0974605d8"}

# telnet 61.155.221.xxx 443
Trying 61.155.221.xxx..

# telnet 61.155.221.xxx 80
Trying 61.155.221.xxx...
Connected to 61.155.221.xxx.
Escape character is '^]'.
```

4. When `exclude-port` is used with `destination-ip`, the `destination-ip` take effect, all of `exclude-port` ports include `destination-ip` port don't take effect. For example:
```
# blade c network loss --percent 100 --timeout 60 --interface eth0 --exclude-port 80 --destination-ip 61.155.221.xxx
{"code":200,"success":true,"result":"f3361c36d4286976"}

# ping 61.155.221.xxx
PING 61.155.221.xxx (61.155.221.xxx) 56(84) bytes of data.
^C
--- 61.155.221.xxx ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms

# telnet 61.155.221.xxx 80
Trying 61.155.221.xxx...
Connected to 61.155.221.xxx.
Escape character is '^]'.

# telnet 61.155.221.xxx 443
Trying 61.155.221.xxx...
^C
```

5. When `exclude-port` is used with `exclude-ip`, all of `exclude-port` or `exclude-ip` don't take effect, other ports or ips take effect. For example:
```
blade c network loss --percent 100 --timeout 60 --interface eth0 --exclude-port 80 --exclude-ip 180.101.49.xxx,42.120.72.xxx
{"code":200,"success":true,"result":"9f56b3263508e096"}

# ping 180.101.49.xxx
PING 180.101.49.12 (180.101.49.xxx) 56(84) bytes of data.
64 bytes from 180.101.49.xxx: icmp_seq=1 ttl=50 time=14.7 ms
64 bytes from 180.101.49.xxx: icmp_seq=2 ttl=50 time=14.6 ms

# telnet 180.101.49.xxx 443
Trying 180.101.49.xxx...
Connected to 180.101.49.xxx.
Escape character is '^]'

# telnet 180.101.49.xxx 80
Trying 180.101.49.xxx...
Connected to 180.101.49.xxx.
Escape character is '^]'

# ping www.xxx.com

```

6.  When the `destination-ip` is used with `exclude-ip`, the `destination-ip` takes effect, the `exclude-ip` doesn't take effect.
```
blade c network loss --percent 100 --timeout 60 --interface eth0 --destination-ip 61.155.221.xxx,180.101.49.xxx --exclude-ip 180.101.49.xxx
{"code":200,"success":true,"result":"d6c6d967a1c13841"}

# ping 61.155.221.xxx
PING 61.155.221.xxx (61.155.221.xxx) 56(84) bytes of data.
^C
--- 61.155.221.xxx ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms

# ping 180.101.49.xxx
PING 180.101.49.xxx (180.101.49.xxx) 56(84) bytes of data.
64 bytes from 180.101.49.xxx: icmp_seq=1 ttl=50 time=14.6 ms
64 bytes from 180.101.49.xxx: icmp_seq=2 ttl=50 time=14.6 ms
```
 



### Special notes for reviews
