### PR TITLE
network delay: set default offset value to 0.

### DIFF
--- a/exec/network_delay.go
+++ b/exec/network_delay.go
@@ -115,7 +115,7 @@ func (de *NetworkDelayExecutor) Exec(uid string, ctx context.Context, model *spe
 		}
 		offset := model.ActionFlags["offset"]
 		if offset == "" {
-			offset = "10"
+			offset = "0"
 		}
 		localPort := model.ActionFlags["local-port"]
 		remotePort := model.ActionFlags["remote-port"]


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

the default offset was always set to 10ms, it's not possible if we want a constant delay time.
and it is not documentated.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

set default value to 0

### Describe how to verify it


### Special notes for reviews
