### PR TITLE
The problem of wrong return value of destroy under non root Linux

### DIFF
--- a/exec/bin/tcnetwork/tcnetwork.go
+++ b/exec/bin/tcnetwork/tcnetwork.go
@@ -377,10 +377,19 @@ func addQdiscForDL(channel spec.Channel, ctx context.Context, netInterface strin
 }
 
 // stopNet, no need to add os.Exit
-func stopNet(netInterface string) {
+func stopNet(netInterface string) *spec.Response{
 	ctx := context.Background()
-	cl.Run(ctx, "tc", fmt.Sprintf(`filter del dev %s parent 1: prio 4`, netInterface))
-	cl.Run(ctx, "tc", fmt.Sprintf(`qdisc del dev %s root`, netInterface))
+	run := cl.Run(ctx, "tc", fmt.Sprintf(`filter del dev %s parent 1: prio 4`, netInterface))
+	response := cl.Run(ctx, "tc", fmt.Sprintf(`qdisc del dev %s root`, netInterface))
+	if !response.Success {
+		bin.PrintErrAndExit(response.Err)
+		return response
+	} else if !run.Success {
+		bin.PrintErrAndExit(run.Err)
+		return run
+	}
+	bin.PrintOutputAndExit(response.Result.(string))
+	return response
 }
 
 // getPeerPorts returns all ports communicating with the port


### PR DESCRIPTION
Signed-off-by: jfl929930 <jfl01231489@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
When the non root account of Linux performs fault injection, failure will be displayed when the non root account is destroyed. In fact, it is a failure. This is a problem.


### Does this pull request fix one issue?
Fixes #597


### Describe how you did it
Judge whether the TC command is executed successfully. If it is successful, it will be destroyed. If it is unsuccessful, an error will be returned and the fault status will not be modified

### Describe how to verify it
![image](https://user-images.githubusercontent.com/66984063/138849864-21ca7805-cc47-4997-8776-d42278f27362.png)
