### PR TITLE
Fix the problem of destroy reporting an error when the network does not add any parameters.

### DIFF
--- a/exec/bin/tcnetwork/tcnetwork.go
+++ b/exec/bin/tcnetwork/tcnetwork.go
@@ -98,7 +98,13 @@ func main() {
 		}
 		startNet(tcNetInterface, classRule, tcLocalPort, tcRemotePort, tcExcludePort, tcDestinationIp, tcExcludeIp, tcForce)
 	} else if tcNetStop {
-		stopNet(tcNetInterface)
+		var delFilter bool
+		if tcLocalPort == "" && tcRemotePort == "" && tcExcludePort == "" && tcDestinationIp == "" && tcExcludeIp == "" {
+			delFilter = false
+		}else {
+			delFilter = true
+		}
+		stopNet(tcNetInterface,delFilter)
 	} else {
 		bin.PrintErrAndExit("less --start or --stop flag")
 	}
@@ -122,7 +128,7 @@ func startNet(netInterface, classRule, localPort, remotePort, excludePort, destI
 		}
 	}
 	if force {
-		stopNet(netInterface)
+		stopNet(netInterface,true)
 	}
 	ctx := context.Background()
 	// Only interface flag
@@ -140,7 +146,7 @@ func startNet(netInterface, classRule, localPort, remotePort, excludePort, destI
 	if excludePort != "" {
 		excludePorts, err = getExcludePorts(excludePort)
 		if err != nil {
-			stopDLNetFunc(netInterface)
+			stopDLNetFunc(netInterface,true)
 			bin.PrintErrAndExit(response.Err)
 		}
 	}
@@ -152,7 +158,7 @@ func startNet(netInterface, classRule, localPort, remotePort, excludePort, destI
 		excludeFilters := buildExcludeFilterToNewBand(netInterface, excludePorts, excludeIp)
 		response := cl.Run(ctx, "tc", args+excludeFilters)
 		if !response.Success {
-			stopDLNetFunc(netInterface)
+			stopDLNetFunc(netInterface,true)
 			bin.PrintErrAndExit(response.Err)
 		}
 		bin.PrintOutputAndExit(response.Result.(string))
@@ -293,7 +299,7 @@ func executeTargetPortAndIpWithExclude(ctx context.Context, channel spec.Channel
 	args = buildTargetFilterPortAndIp(localPort, remotePort, destIpRules, excludePorts, excludeIpRules, args, netInterface)
 	response := channel.Run(ctx, "tc", args)
 	if !response.Success {
-		stopDLNetFunc(netInterface)
+		stopDLNetFunc(netInterface,true)
 		bin.PrintErrAndExit(response.Err)
 	}
 	return response
@@ -377,16 +383,20 @@ func addQdiscForDL(channel spec.Channel, ctx context.Context, netInterface strin
 }
 
 // stopNet, no need to add os.Exit
-func stopNet(netInterface string) *spec.Response{
+func stopNet(netInterface string,delFilter bool) *spec.Response{
 	ctx := context.Background()
-	run := cl.Run(ctx, "tc", fmt.Sprintf(`filter del dev %s parent 1: prio 4`, netInterface))
+	if delFilter {
+		run := cl.Run(ctx, "tc", fmt.Sprintf(`filter del dev %s parent 1: prio 4`, netInterface))
+		if !run.Success {
+			bin.PrintErrAndExit(run.Err)
+			return run
+		}
+	}
 	response := cl.Run(ctx, "tc", fmt.Sprintf(`qdisc del dev %s root`, netInterface))
 	if !response.Success {
+		logrus.Infof("qdisc del error")
 		bin.PrintErrAndExit(response.Err)
 		return response
-	} else if !run.Success {
-		bin.PrintErrAndExit(run.Err)
-		return run
 	}
 	bin.PrintOutputAndExit(response.Result.(string))
 	return response

--- a/exec/bin/tcnetwork/tcnetwork.go
+++ b/exec/bin/tcnetwork/tcnetwork.go
@@ -377,10 +377,19 @@ func addQdiscForDL(channel spec.Channel, ctx context.Context, netInterface strin
 }
 
 // stopNet, no need to add os.Exit
-func stopNet(netInterface string) {
+func stopNet(netInterface string) *spec.Response{
 	ctx := context.Background()
-	cl.Run(ctx, "tc", fmt.Sprintf(`filter del dev %s parent 1: prio 4`, netInterface))
-	cl.Run(ctx, "tc", fmt.Sprintf(`qdisc del dev %s root`, netInterface))
+	run := cl.Run(ctx, "tc", fmt.Sprintf(`filter del dev %s parent 1: prio 4`, netInterface))
+	response := cl.Run(ctx, "tc", fmt.Sprintf(`qdisc del dev %s root`, netInterface))
+	if !response.Success {
+		bin.PrintErrAndExit(response.Err)
+		return response
+	} else if !run.Success {
+		bin.PrintErrAndExit(run.Err)
+		return run
+	}
+	bin.PrintOutputAndExit(response.Result.(string))
+	return response
 }
 
 // getPeerPorts returns all ports communicating with the port


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
When the network delay scenario is executed without adding any parameters, destroy will report an error

### Does this pull request fix one issue?
yes
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Before destroy, judge whether there are parameters during create. If not, TC filter del will not be executed.

### Describe how to verify it
no parameter create blade,after success，destroy this blade


