### PR TITLE
Fix the execution failure of file content appending scene

### DIFF
--- a/exec/bin/file/appendfile/appendfile.go
+++ b/exec/bin/file/appendfile/appendfile.go
@@ -200,9 +200,9 @@ func append(count int, ctx context.Context, content string, filepath string, esc
 	for i := 0; i < count; i++ {
 		content = parseRandom(content)
 		if escape {
-			response = cl.Run(ctx, "echo", fmt.Sprintf(`-e "%s" >> "%s"`, content, filepath))
+			response = cl.Run(ctx, "echo", fmt.Sprintf(`-e '%s' >> %s`, content, filepath))
 		} else {
-			response = cl.Run(ctx, "echo", fmt.Sprintf(`"%s" >> "%s"`, content, filepath))
+			response = cl.Run(ctx, "echo", fmt.Sprintf(`'%s' >> %s`, content, filepath))
 		}
 		if !response.Success {
 			bin.PrintErrAndExit(response.Err)

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func createExpModel(target, actionName string, flags []string) *spec.ExpModel {
 		ActionFlags: make(map[string]string, 0),
 	}
 	for _, flag := range flags {
-		split := strings.Split(flag, SEPARATOR)
+		split := strings.SplitN(flag, SEPARATOR, 2)
 		if len(split) == 2 {
 			expModel.ActionFlags[split[0]] = split[1]
 		} else {


### PR DESCRIPTION
Signed-off-by: xcaspar <changjun.xcj@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
chaosblade-io/chaosblade#636

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Solve the problem of equal sign under base64 encoding.

### Describe how to verify it
Package and test it.
```
[root@zk003 chaosblade-1.4.0]# ./blade create file append --debug 'true' --filepath '/root/common-alarm.log' --count '2' --enable-base64 'true' --interval '1' --content 'eyJrZXl3b3JkIjoiU2FlSm9iRXJyb3IiLCJtZXNzYWdlIjoiY2hhb3MtLUt1YmVybmV0ZXNBY3JUb2tlblVwZGF0ZUpvYiNoYW5kbGVTeW5jQnlLOHNOYW1lc3BhY2UgZXhlY3V0ZSBlcnJvciwgcGxlYXNlIGNoZWNrIHlvdSBqb2IhIGVycm9yIG1lc3NhZ2UgaXMgSW52b2NhdGlvbiBmYWlsZWQuIiwidGltZSI6MTYzOTY3MDU1MTY5OX0='
{"code":200,"success":true,"result":"a31d75e1dd39a999"}
```
```
#cat /root/common-alarm.log

{"keyword":"SaeJobError","message":"chaos--KubernetesAcrTokenUpdateJob#handleSyncByK8sNamespace execute error, please check you job! error message is Invocation failed.","time":1639670551699}
```

### Special notes for reviews
