### PR TITLE
Fix memory overflow experimental scene problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GO_FLAGS=-ldflags="-s -w"
 UNAME := $(shell uname)
 
 ifeq ($(BLADE_VERSION), )
-	BLADE_VERSION=1.4.0
+	BLADE_VERSION=1.5.0
 endif
 
 BUILD_TARGET=target

--- a/exec/bin/burnmem/burnmem.go
+++ b/exec/bin/burnmem/burnmem.go
@@ -43,8 +43,10 @@ import (
 const PageCounterMax uint64 = 9223372036854770000
 
 const (
-	processOOMScoreAdj = "/proc/%s/oom_score_adj"
-	oomMinScore        = "-1000"
+	//processOOMScoreAdj = "/proc/%s/oom_score_adj"
+	//oomMinScore        = "-1000"
+	processOOMAdj      = "/proc/%s/oom_adj"
+	oomMinAdj          = "-17"
 )
 
 // 128K
@@ -211,12 +213,12 @@ func runBurnMem(ctx context.Context, memPercent, memReserve, memRate int, burnMe
 	// adjust process oom_score_adj to avoid being killed
 	if avoidBeingKilled {
 		for _, pid := range pids {
-			scoreAdjFile := fmt.Sprintf(processOOMScoreAdj, pid)
+			scoreAdjFile := fmt.Sprintf(processOOMAdj, pid)
 			if _, err := os.Stat(scoreAdjFile); os.IsNotExist(err) {
 				continue
 			}
 
-			if err := ioutil.WriteFile(scoreAdjFile, []byte(oomMinScore), 0644); err != nil {
+			if err := ioutil.WriteFile(scoreAdjFile, []byte(oomMinAdj), 0644); err != nil {
 				stopBurnMemFunc()
 				bin.PrintErrAndExit(fmt.Sprintf("run burn memory by %s mode failed, cannot edit the process oom_score_adj",
 					burnMemMode))


### PR DESCRIPTION
Signed-off-by: xcaspar <changjun.xcj@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Modify the file written to the oom score from `/proc/%s/oom_score_adj` to `/proc/%s/oom_adj`.

### Describe how to verify it
Package and test it.
```
blade c mem load --avoid-being-killed --mode ram
```

### Special notes for reviews
The`--avoid-being-killed` flag must be added to prevent the process from being killed.