### PR TITLE
feature: add self-verify type dns & occupy & ping of tc network

### DIFF
--- a/exec/network/network_curl.go
+++ b/exec/network/network_curl.go
@@ -93,7 +93,7 @@ func (nce *NetworkCurlExecutor) Exec(uid string, ctx context.Context, model *spe
 }
 
 func (nce *NetworkCurlExecutor) verify(ctx context.Context, url string) *spec.Response {
-	response := nce.channel.Run(ctx, "curl", fmt.Sprintf(`%s`, url))
+	response := nce.channel.Run(ctx, "curl", fmt.Sprintf(`-s %s`, url))
 	if !response.Success {
 		return spec.ResponseFailWithFlags(spec.OsCmdExecFailed, "curl", response.Err)
 	}

--- a/exec/network/network_curl.go
+++ b/exec/network/network_curl.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+)
+
+const CurlNetworkBin = "chaos_curlnetwork"
+
+type CurlActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewCurlActionSpec() spec.ExpActionCommandSpec {
+	return &CurlActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "url",
+					Desc:     "Url",
+					Required: true,
+				},
+			},
+			ActionExecutor: &NetworkCurlExecutor{},
+			ActionExample: `
+# Curl url
+blade verify network curl --url 11.11.11.11:9001/result`,
+			ActionPrograms:   []string{CurlNetworkBin},
+			ActionCategories: []string{category.SystemNetwork},
+		},
+	}
+}
+
+func (*CurlActionSpec) Name() string {
+	return "curl"
+}
+
+func (*CurlActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*CurlActionSpec) ShortDesc() string {
+	return "Curl verify command"
+}
+
+func (c *CurlActionSpec) LongDesc() string {
+	if c.ActionLongDesc != "" {
+		return c.ActionLongDesc
+	}
+	return "Curl experiment"
+}
+
+type NetworkCurlExecutor struct {
+	channel spec.Channel
+}
+
+func (*NetworkCurlExecutor) Name() string {
+	return "curl"
+}
+
+func (nce *NetworkCurlExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	commands := []string{"curl"}
+	if response, ok := nce.channel.IsAllCommandsAvailable(ctx, commands); !ok {
+		return response
+	}
+
+	url := model.ActionFlags["url"]
+	if url == "" {
+		log.Errorf(ctx, "url is nil")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "url")
+	}
+	return nce.verify(ctx, url)
+}
+
+func (nce *NetworkCurlExecutor) verify(ctx context.Context, url string) *spec.Response {
+	response := nce.channel.Run(ctx, "curl", fmt.Sprintf(`%s`, url))
+	if !response.Success {
+		return spec.ResponseFailWithFlags(spec.OsCmdExecFailed, "curl", response.Err)
+	}
+	return spec.ReturnSuccess(response.Result)
+}
+
+func (nce *NetworkCurlExecutor) SetChannel(channel spec.Channel) {
+	nce.channel = channel
+}

--- a/exec/network/network_darwin.go
+++ b/exec/network/network_darwin.go
@@ -27,6 +27,7 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				NewDropActionSpec(),
 				NewDnsActionSpec(),
 				NewOccupyActionSpec(),
+				NewPingActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/network/network_darwin.go
+++ b/exec/network/network_darwin.go
@@ -30,6 +30,7 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				NewPingActionSpec(),
 				NewListenActionSpec(),
 				NewSendActionSpec(),
+				NewCurlActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/network/network_darwin.go
+++ b/exec/network/network_darwin.go
@@ -28,6 +28,8 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				NewDnsActionSpec(),
 				NewOccupyActionSpec(),
 				NewPingActionSpec(),
+				NewListenActionSpec(),
+				NewSendActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/network/network_linux.go
+++ b/exec/network/network_linux.go
@@ -33,6 +33,7 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				tc.NewCorruptActionSpec(),
 				tc.NewReorderActionSpec(),
 				NewOccupyActionSpec(),
+				NewPingActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/network/network_linux.go
+++ b/exec/network/network_linux.go
@@ -36,6 +36,7 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				NewPingActionSpec(),
 				NewListenActionSpec(),
 				NewSendActionSpec(),
+				NewCurlActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/network/network_linux.go
+++ b/exec/network/network_linux.go
@@ -34,6 +34,8 @@ func NewNetworkCommandSpec() spec.ExpModelCommandSpec {
 				tc.NewReorderActionSpec(),
 				NewOccupyActionSpec(),
 				NewPingActionSpec(),
+				NewListenActionSpec(),
+				NewSendActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/network/network_listen.go
+++ b/exec/network/network_listen.go
@@ -1,0 +1,443 @@
+package network
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/network/tc"
+	"github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"net"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const ListenNetworkBin = "chaos_listennetwork"
+const (
+	Remote = "remote"
+	Local  = "local"
+)
+const (
+	SHAKEHAND = "SHAKEHAND"
+)
+
+// such as lost pkg number for loss, duplicate pkg number for duplicate
+var listenValueInt int
+
+// ListenValue listen result, x represents molecular, y represents denominator
+type ListenValue struct {
+	x int
+	y int
+}
+
+var listenValue ListenValue
+
+type ListenActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewListenActionSpec() spec.ExpActionCommandSpec {
+	return &ListenActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "interface",
+					Desc:     "Network interface, for example, eth0",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "type",
+					Desc:     "Type, Optional value: loss, duplicate, reorder, corrupt, delay",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "direction",
+					Desc:     "Listen direction, Optional value: remote | local",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "local-port",
+					Desc:     "Local port, Required when direction is local",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "destination-ip",
+					Desc:     "Destination ip, optional when direction is out",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "remote-port",
+					Desc:     "Remote port, required when direction is remote",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "http-port",
+					Desc:     "Http port, used for communication packet capture results, No need to fill in manually",
+					Required: false,
+				},
+			},
+			ActionExecutor: &NetworkListenExecutor{},
+			ActionExample: `
+# Listen packet loss on port 9001
+blade verify network listen --interface eth0 --direction local --type loss --local-port 9001`,
+			ActionPrograms:   []string{ListenNetworkBin},
+			ActionCategories: []string{category.SystemNetwork},
+		},
+	}
+}
+
+func (*ListenActionSpec) Name() string {
+	return "listen"
+}
+
+func (*ListenActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*ListenActionSpec) ShortDesc() string {
+	return "listen tcp port"
+}
+
+func (l *ListenActionSpec) LongDesc() string {
+	if l.ActionLongDesc != "" {
+		return l.ActionLongDesc
+	}
+	return "Listen tcp port"
+}
+
+type NetworkListenExecutor struct {
+	channel spec.Channel
+}
+
+func (nle *NetworkListenExecutor) SetChannel(channel spec.Channel) {
+	nle.channel = channel
+}
+
+func (*NetworkListenExecutor) Name() string {
+	return "listen"
+}
+
+func (nle *NetworkListenExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		log.Errorf(ctx, "Listen only supports create or verify")
+		return spec.ReturnFail(spec.CommandIllegal, "Listen only supports create or verify")
+	}
+
+	var dev string
+	var localPort int
+	var destinationIp string
+	var remotePort int
+	var listenType string
+	var direction string
+	var httpPort int
+	var err error
+
+	if netInterface, ok := model.ActionFlags["interface"]; ok {
+		if netInterface == "" {
+			log.Errorf(ctx, "interface is nil")
+			return spec.ResponseFailWithFlags(spec.ParameterLess, "interface")
+		}
+		dev = netInterface
+	}
+
+	listenType = model.ActionFlags["type"]
+	if listenType != tc.Loss && listenType != tc.Duplicate && listenType != tc.Reorder && listenType != tc.Corrupt && listenType != tc.Delay {
+		log.Errorf(ctx, "`%s`: type is illegal, it must be (loss | duplicate | reorder | corrupt | delay)", listenType)
+		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "type", listenType,
+			"it must be (loss | duplicate | reorder | corrupt | delay)")
+	}
+
+	direction = model.ActionFlags["direction"]
+	if direction != Remote && direction != Local {
+		log.Errorf(ctx, "`%s`: direction is illegal, it must be (out | in)", direction)
+		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "direction", direction,
+			"it must be (out | in)")
+	}
+	if direction == Remote {
+		destinationIp = model.ActionFlags["destination-ip"]
+		if remotePort, err = strconv.Atoi(model.ActionFlags["remote-port"]); err != nil {
+			log.Errorf(ctx, "remote-port is nil")
+			return spec.ResponseFailWithFlags(spec.ParameterLess, "remote-port")
+		}
+	} else if direction == Local {
+		if localPort, err = strconv.Atoi(model.ActionFlags["local-port"]); err != nil {
+			log.Errorf(ctx, "local-port is nil")
+			return spec.ResponseFailWithFlags(spec.ParameterLess, "local-port")
+		}
+	}
+
+	httpPortStr := model.ActionFlags["http-port"]
+	if httpPortStr == "" {
+		if port, err := util.GetUnusedPort(); err != nil {
+			log.Errorf(ctx, "get unused port error: %v", err.Error())
+			return spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("get unused port error: %v", err.Error()))
+		} else {
+			flags := fillFlags(dev, localPort, destinationIp, remotePort, listenType, direction, port)
+			response := channel.NewLocalChannel().
+				Run(context.Background(), "nohup", fmt.Sprintf("%s %s", path.Join(nle.channel.GetScriptPath(),
+					"chaos_os"), flags))
+			if !response.Success {
+				log.Errorf(ctx, fmt.Sprintf("%s %s", path.Join(nle.channel.GetScriptPath(), "chaos_os"), flags))
+				return spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("%s %s", path.Join(nle.channel.GetScriptPath(), "chaos_os"), flags))
+			}
+			return spec.ReturnSuccess(port)
+		}
+	} else {
+		if httpPort, err = strconv.Atoi(httpPortStr); err != nil {
+			return spec.ResponseFailWithFlags(spec.ParameterIllegal, "http-port", httpPortStr, "cpu-percent is illegal, it must be a positive integer")
+		}
+	}
+
+	return nle.start(ctx, dev, listenType, direction, localPort, destinationIp, remotePort, httpPort)
+}
+
+func fillFlags(dev string, localPort int, destinationIp string, remotePort int, listenType string, direction string, httpPort int) string {
+	flags := fmt.Sprintf(" verify network listen --interface %s --direction %s --http-port %v --type %s ", dev, direction, httpPort, listenType)
+	if direction == Local {
+		flags = flags + fmt.Sprintf(" --local-port %v >/dev/null 2>&1 &", localPort)
+	} else {
+		flags = flags + fmt.Sprintf(" --remotePort %v --destinationIp %s >/dev/null 2>&1 &", remotePort, destinationIp)
+	}
+	return flags
+}
+
+func (nle *NetworkListenExecutor) start(ctx context.Context, dev string, listenType string, direction string, localPort int,
+	destinationIp string, remotePort int, httpPort int) *spec.Response {
+	// start capture tcp packages
+	response := startCapture(ctx, dev, listenType, direction, localPort, destinationIp, remotePort)
+	if !response.Success {
+		log.Errorf(ctx, "start capture tcp packages failed, %s", response.Err)
+		return response
+	}
+
+	// start http server
+	return startHttpServer(ctx, httpPort)
+}
+
+func startHttpServer(ctx context.Context, httpPort int) *spec.Response {
+	http.HandleFunc("/result", func(writer http.ResponseWriter, request *http.Request) {
+		marshal, _ := json.Marshal(map[string]int{"x": listenValue.x, "y": listenValue.y})
+		_, err := fmt.Fprintf(writer, fmt.Sprintf("%s", string(marshal)))
+		if err != nil {
+			log.Errorf(ctx, err.Error())
+			return
+		}
+	})
+	http.HandleFunc("/stop", func(writer http.ResponseWriter, request *http.Request) {
+		os.Exit(0)
+	})
+	err := http.ListenAndServe(fmt.Sprintf(":%d", httpPort), nil)
+	if err != nil {
+		log.Errorf(ctx, "start http sever failed, %s", err.Error())
+		return spec.ReturnFail(spec.OsCmdExecFailed, "start http sever failed")
+	}
+	return spec.ReturnSuccess(httpPort)
+}
+
+func startCapture(ctx context.Context, dev string, listenType string, direction string, localPort int, destinationIp string, remotePort int) *spec.Response {
+	snapLen := int32(65535)
+
+	ipv4Addr, err := GetInterfaceIpv4Addr(dev)
+	if err != nil {
+		log.Errorf(ctx, "Failed to get ipv4 address of network interface")
+		return spec.ReturnFail(spec.OsCmdExecFailed, "Get ipv4 addr failed")
+	}
+
+	var filter string
+	if direction == Local {
+		filter = getLocalFilter(localPort, ipv4Addr)
+	} else if direction == Remote {
+		filter = getRemoteFilter(remotePort, destinationIp)
+	}
+
+	// start network listen handle
+	handle, err := pcap.OpenLive(dev, snapLen, true, pcap.BlockForever)
+	if err != nil {
+		log.Errorf(ctx, "pcap open live failed: %v", err)
+		return spec.ReturnFail(spec.OsCmdExecFailed, "Pcap open live failed")
+	}
+
+	// set handle filter
+	if err = handle.SetBPFFilter(filter); err != nil {
+		log.Errorf(ctx, "set bpf filter failed: %v", err)
+		return spec.ReturnFail(spec.OsCmdExecFailed, "Set BPF filter failed")
+	}
+
+	go doCapture(ctx, handle, listenType, ipv4Addr)
+	return spec.Success()
+}
+
+func doCapture(ctx context.Context, handle *pcap.Handle, listenType string, ip string) {
+	// 抓包
+	defer handle.Close()
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+	packetSource.NoCopy = true
+	switch listenType {
+	case tc.Loss:
+		onLoss(ctx, packetSource, ip)
+	case tc.Reorder:
+		onReorder(ctx, packetSource)
+	case tc.Duplicate:
+		onDuplicate(ctx, packetSource)
+	case tc.Corrupt:
+		onCorrupt(ctx, packetSource, ip)
+	case tc.Delay:
+		onDelay(ctx, packetSource, ip)
+	}
+}
+
+func onDelay(ctx context.Context, packetSource *gopacket.PacketSource, ipAddr string) {
+	// Ack number 2 timestamp
+	expectedAck2Time := make(map[string]int64)
+
+	for packet := range packetSource.Packets() {
+		if packet.NetworkLayer() == nil || packet.TransportLayer() == nil || packet.TransportLayer().LayerType() != layers.LayerTypeTCP {
+			log.Warnf(ctx, "unexpected packet")
+			continue
+		}
+
+		ip := packet.NetworkLayer().(*layers.IPv4)
+		tcp := packet.TransportLayer().(*layers.TCP)
+
+		if ip.SrcIP.String() != ipAddr {
+			expectedAck := tcp.Seq + uint32(len(tcp.Payload))
+			if tcp.SYN || tcp.FIN {
+				expectedAck += 1
+			}
+			expectedAck2Time[ip.SrcIP.String()+strconv.FormatUint(uint64(expectedAck), 10)] = time.Now().UnixNano() / 1000000
+		} else {
+			if tcp.ACK {
+				receiveTime := expectedAck2Time[ip.DstIP.String()+strconv.FormatUint(uint64(tcp.Ack), 10)]
+				if receiveTime > 0 {
+					delay := time.Now().UnixNano()/1000000 - receiveTime
+					listenValue.x += int(delay)
+					listenValue.y++
+				}
+			}
+		}
+	}
+}
+
+func onDuplicate(ctx context.Context, packetSource *gopacket.PacketSource) {
+	for packet := range packetSource.Packets() {
+		if packet.NetworkLayer() == nil || packet.TransportLayer() == nil || packet.TransportLayer().LayerType() != layers.LayerTypeTCP {
+			log.Warnf(ctx, "unexpected packet")
+			continue
+		}
+
+		// Custom TCP protocol, for example: "chaos:SHAKEHAND"
+		tcp := packet.TransportLayer().(*layers.TCP)
+		payload := fmt.Sprintf("%s", tcp.Payload)
+		keyValuePair := strings.Split(payload, ":")
+		if !strings.HasPrefix(payload, "chaos") || len(keyValuePair) != 2 {
+			log.Warnf(ctx, "unexpected packet")
+			continue
+		}
+
+		seqMap := make(map[uint32]bool)
+		if strings.HasPrefix(keyValuePair[1], SHAKEHAND) {
+			if seqMap[tcp.Seq] == true {
+				listenValueInt++
+			} else {
+				seqMap[tcp.Seq] = true
+			}
+		}
+	}
+}
+
+func onReorder(ctx context.Context, packetSource *gopacket.PacketSource) {
+	for packet := range packetSource.Packets() {
+		if packet.NetworkLayer() == nil || packet.TransportLayer() == nil || packet.TransportLayer().LayerType() != layers.LayerTypeTCP {
+			log.Warnf(ctx, "unexpected packet")
+			continue
+		}
+
+		// Custom TCP protocol, for example: "chaos:SHAKEHAND"
+		tcp := packet.TransportLayer().(*layers.TCP)
+		payload := fmt.Sprintf("%s", tcp.Payload)
+		keyValuePair := strings.Split(payload, ":")
+		if !strings.HasPrefix(payload, "chaos") || len(keyValuePair) != 2 {
+			log.Warnf(ctx, "unexpected packet")
+			continue
+		}
+
+		var maxSeq uint32
+		if strings.HasPrefix(keyValuePair[1], SHAKEHAND) {
+			if tcp.Seq > maxSeq {
+				maxSeq = tcp.Seq
+			} else {
+				listenValueInt++
+			}
+		}
+	}
+}
+
+/**
+For loss listen verify, we just need to count received pkg number, then box calculate with send pkg number
+*/
+func onLoss(ctx context.Context, packetSource *gopacket.PacketSource, ipAddr string) {
+	for packet := range packetSource.Packets() {
+		if packet.NetworkLayer() == nil || packet.TransportLayer() == nil || packet.TransportLayer().LayerType() != layers.LayerTypeTCP {
+			log.Warnf(ctx, "unexpected packet")
+			continue
+		}
+		ip := packet.NetworkLayer().(*layers.IPv4)
+
+		if ipAddr == ip.SrcIP.String() {
+			listenValue.x++
+		} else {
+			listenValue.y++
+		}
+	}
+}
+
+func onCorrupt(ctx context.Context, packetSource *gopacket.PacketSource, dev string) {
+	onLoss(ctx, packetSource, dev)
+}
+
+func GetInterfaceIpv4Addr(interfaceName string) (addr string, err error) {
+	var (
+		ief      *net.Interface
+		addrs    []net.Addr
+		ipv4Addr net.IP
+	)
+	if ief, err = net.InterfaceByName(interfaceName); err != nil {
+		return "", err
+	}
+	if addrs, err = ief.Addrs(); err != nil {
+		return "", err
+	}
+	for _, addr := range addrs { // get ipv4 address
+		if ipv4Addr = addr.(*net.IPNet).IP.To4(); ipv4Addr != nil {
+			break
+		}
+	}
+	if ipv4Addr == nil {
+		return "", errors.New(fmt.Sprintf("interface %s don't have an ipv4 address", interfaceName))
+	}
+	return ipv4Addr.String(), nil
+}
+
+func getLocalFilter(port int, ip string) string {
+	return fmt.Sprintf("tcp and (src host %v and src port %v) or (dst host %v and dst port %v)", ip, port, ip, port)
+}
+
+func getRemoteFilter(port int, ip string) string {
+	if ip != "" {
+		return fmt.Sprintf("(src host %v and src port %v) or (dst host %v and dst port %v)", ip, port, ip, port)
+	} else {
+		return fmt.Sprintf("tcp and port %v", port)
+	}
+}

--- a/exec/network/network_ping.go
+++ b/exec/network/network_ping.go
@@ -1,0 +1,398 @@
+package network
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/network/tc"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var PingNetworkBin = "chaos_pingnetwork"
+
+type PingParams struct {
+	experimentType  string
+	destinationIp   string
+	quantity        int
+	duration        int
+	expectedPercent int
+	expectedDelay   int
+	tolerance       int
+}
+
+type PingActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewPingActionSpec() spec.ExpActionCommandSpec {
+	return &PingActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "destination-ip",
+					Desc:     "Destination ip",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "quantity",
+					Desc:     "Quantity of ping packets",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "duration",
+					Desc:     "Duration",
+					Required: false,
+					Default:  "3",
+				},
+				&spec.ExpFlag{
+					Name:     "type",
+					Desc:     "Type",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "expected-percent",
+					Desc:     "Expected Percent, only valid when type is loss or duplicate or reorder or corrupt",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "expected-delay",
+					Desc:     "Expected Delay, only valid when type is delay",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "tolerance",
+					Desc:     "Tolerance, expected-percent 50 tolerance 10 represents 40% - 60%",
+					Required: false,
+				},
+			},
+			ActionExecutor: &NetworkPingExecutor{},
+			ActionExample: `
+# Verify that the network loss experiment is valid
+blade verify network ping --type loss --destination-ip 11.11.11.11 --expected-percent 80 --tolerance 10
+
+# Verify that the network duplicate experiment is valid
+blade verify network ping --type duplicate --destination-ip 11.11.11.11 --expected-percent 80 --tolerance 10
+
+# Verify that the network reorder experiment is valid
+blade verify network ping --type reorder --destination-ip 11.11.11.11 --expected-percent 80 --tolerance 10
+
+# Verify that the network corrupt experiment is valid
+blade verify network ping --type corrupt --destination-ip 11.11.11.11 --expected-percent 80 --tolerance 10
+
+# Verify that the network delay experiment is valid
+blade verify network ping --type delay --destination-ip 11.11.11.11 --expected-delay 3000 --tolerance 1000`,
+			ActionPrograms:   []string{PingNetworkBin},
+			ActionCategories: []string{category.SystemNetwork},
+		},
+	}
+}
+
+func (*PingActionSpec) Name() string {
+	return "ping"
+}
+
+func (*PingActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*PingActionSpec) ShortDesc() string {
+	return "ping experiment"
+}
+
+func (p *PingActionSpec) LongDesc() string {
+	if p.ActionLongDesc != "" {
+		return p.ActionLongDesc
+	}
+	return "Ping experiment"
+}
+
+type NetworkPingExecutor struct {
+	channel spec.Channel
+}
+
+func (*NetworkPingExecutor) Name() string {
+	return "ping"
+}
+
+func (npe *NetworkPingExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	commands := []string{"ping"}
+	if response, ok := npe.channel.IsAllCommandsAvailable(ctx, commands); !ok {
+		return response
+	}
+
+	if _, ok := spec.IsDestroy(ctx); ok {
+		log.Errorf(ctx, "Ping only supports create or verify")
+		return spec.ReturnFail(spec.CommandIllegal, "Ping only supports create or verify")
+	}
+
+	if pingParams, response := checkPingParams(ctx, model.ActionFlags); !response.Success {
+		return response
+	} else {
+		return npe.start(ctx, pingParams)
+	}
+}
+
+func checkPercent(percent float64, expectedPercent int, tolerance int) bool {
+	return percent >= float64(expectedPercent-tolerance) && percent <= float64(expectedPercent+tolerance)
+}
+
+func checkPingParams(ctx context.Context, actionFlags map[string]string) (*PingParams, *spec.Response) {
+	pingParams := &PingParams{}
+	var quantity int
+	var duration int
+	var expectedPercent int
+	var expectedDelay int
+	var tolerance int
+
+	experimentType := actionFlags["type"]
+	destinationIp := actionFlags["destination-ip"]
+	quantityStr := actionFlags["quantity"]
+	durationStr := actionFlags["duration"]
+	expectedPercentStr := actionFlags["expected-percent"]
+	expectedDelayStr := actionFlags["expected-delay"]
+	toleranceStr := actionFlags["tolerance"]
+
+	if experimentType == "" || destinationIp == "" {
+		log.Errorf(ctx, "type|destinationIp is nil")
+		return pingParams, spec.ResponseFailWithFlags(spec.ParameterLess, "type|destination-ip")
+	}
+
+	if experimentType != tc.Loss && experimentType != tc.Duplicate && experimentType != tc.Reorder && experimentType != tc.Corrupt && experimentType != tc.Delay {
+		log.Errorf(ctx, "`%s`: type is illegal, it must be (loss | duplicate | reorder | corrupt | delay)", experimentType)
+		return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "type", experimentType,
+			"it must be (loss | duplicate | reorder | corrupt | delay)")
+	}
+
+	if experimentType == tc.Delay {
+		var err error
+		expectedDelay, err = strconv.Atoi(expectedDelayStr)
+		if err != nil {
+			log.Errorf(ctx, "`%s`: expectedDelay is illegal, it must be a positive integer", expectedDelay)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "expected-delay", expectedDelayStr, "it must be a positive integer")
+		}
+		if expectedDelay <= 0 {
+			log.Errorf(ctx, "`%s`: expectedDelay is illegal, it must be a positive integer and not less than 0", expectedDelay)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "expected-delay", expectedDelayStr,
+				"it must be a positive integer and not less than 0")
+		}
+	} else {
+		var err error
+		expectedPercent, err = strconv.Atoi(expectedPercentStr)
+		if err != nil {
+			log.Errorf(ctx, "`%s`: expectedPercent is illegal, it must be a positive integer", expectedPercent)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "expected-percent", expectedPercentStr, "it must be a positive integer")
+		}
+		if expectedPercent < 0 || expectedPercent > 100 {
+			log.Errorf(ctx, "`%s`: expectedPercent is illegal, it must be a positive integer and between 0 and 100", expectedDelay)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "expected-percent", expectedPercentStr,
+				"it must be a positive integer and between 0 and 100")
+		}
+	}
+
+	if quantityStr != "" {
+		var err error
+		quantity, err = strconv.Atoi(quantityStr)
+		if err != nil {
+			log.Errorf(ctx, "`%s`: quantity is illegal, it must be a positive integer", quantityStr)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "quantity", quantityStr, "it must be a positive integer")
+		}
+		if quantity <= 0 {
+			log.Errorf(ctx, "`%s`: quantity is illegal, it must be a positive integer and not less than 0", quantityStr)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "quantity", quantityStr,
+				"it must be a positive integer and not less than 100")
+		}
+	} else {
+		quantity = 100
+	}
+
+	if durationStr != "" {
+		var err error
+		duration, err = strconv.Atoi(durationStr)
+		if err != nil {
+			log.Errorf(ctx, "`%s`: duration is illegal, it must be a positive integer", durationStr)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "duration", durationStr,
+				"it must be a positive integer")
+		}
+		if duration <= 0 {
+			log.Errorf(ctx, "`%s`: duration is illegal, it must be a positive integer and not less than 0", durationStr)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "duration", durationStr,
+				"it must be a positive integer and not less than 0")
+		}
+	} else {
+		duration = 3
+	}
+
+	if toleranceStr != "" {
+		var err error
+		tolerance, err = strconv.Atoi(toleranceStr)
+		if err != nil {
+			log.Errorf(ctx, "`%s`: tolerance is illegal, it must be a positive integer", toleranceStr)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "tolerance", toleranceStr,
+				"it must be a positive integer")
+		}
+		if tolerance <= 0 {
+			log.Errorf(ctx, "`%s`: duration is illegal, it must be a positive integer and not less than 0", toleranceStr)
+			return pingParams, spec.ResponseFailWithFlags(spec.ParameterIllegal, "tolerance", toleranceStr,
+				"it must be a positive integer and not less than 0")
+		}
+	} else {
+		tolerance = 10
+	}
+
+	pingParams.tolerance = tolerance
+	pingParams.expectedDelay = expectedDelay
+	pingParams.expectedPercent = expectedPercent
+	pingParams.duration = duration
+	pingParams.quantity = quantity
+	pingParams.destinationIp = destinationIp
+	pingParams.experimentType = experimentType
+	return pingParams, spec.Success()
+}
+
+func (npe *NetworkPingExecutor) SetChannel(channel spec.Channel) {
+	npe.channel = channel
+}
+
+func (npe *NetworkPingExecutor) start(ctx context.Context, params *PingParams) *spec.Response {
+	switch params.experimentType {
+	case tc.Loss:
+		return npe.onLoss(ctx, params)
+	case tc.Corrupt:
+		return npe.onCorrupt(ctx, params)
+	case tc.Reorder:
+		return npe.onReorder(ctx, params)
+	case tc.Duplicate:
+		return npe.onDuplicate(ctx, params)
+	case tc.Delay:
+		return npe.onDelay(ctx, params)
+	default:
+		return spec.ReturnFail(spec.ParameterIllegal, "UnSupported type")
+	}
+}
+
+func (npe *NetworkPingExecutor) onDelay(ctx context.Context, params *PingParams) *spec.Response {
+	interval, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(params.duration)/float64(params.quantity)), 64)
+	response := npe.channel.Run(ctx, "ping", fmt.Sprintf(`%s -i %.2f -c %d -A | grep "icmp_seq" | awk -F '[ =]' '{print $10}'`,
+		params.destinationIp, interval, params.quantity))
+	if !response.Success {
+		return spec.ReturnFail(spec.OsCmdExecFailed, response.Err)
+	}
+
+	var delayCount int
+	delayList := strings.Split(response.Result.(string), "\n")
+	for _, delayStr := range delayList {
+		if delay, err := strconv.Atoi(strings.TrimSpace(delayStr)); err == nil {
+			delayCount += delay
+		}
+	}
+
+	averageDelay := float64(delayCount) / float64(params.quantity)
+	if checkPercent(averageDelay, params.expectedDelay, params.tolerance) {
+		delayJson, _ := json.Marshal(map[string]float64{"averageDelay": averageDelay})
+		return spec.ReturnSuccess(string(delayJson))
+	} else {
+		return spec.ResponseFailWithFlags(spec.PingSelfVerifyFailed, params.experimentType, fmt.Sprintf("%d", params.expectedDelay), fmt.Sprintf("%.2f", averageDelay))
+	}
+}
+
+func (npe *NetworkPingExecutor) onDuplicate(ctx context.Context, params *PingParams) *spec.Response {
+	interval, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(params.duration)/float64(params.quantity)), 64)
+	response := npe.channel.Run(ctx, "ping", fmt.Sprintf(`%s -i %.2f -c %d -A | grep "icmp_seq" | grep "DUP!" | wc -l`, params.destinationIp, interval, params.quantity))
+	if !response.Success {
+		return spec.ReturnFail(spec.OsCmdExecFailed, response.Err)
+	}
+
+	duplicate, _ := strconv.Atoi(strings.TrimSpace(response.Result.(string)))
+	duplicatePercent := float64(duplicate) * 100 / float64(params.quantity)
+	if checkPercent(duplicatePercent, params.expectedPercent, params.tolerance) {
+		duplicateJson, _ := json.Marshal(map[string]float64{"duplicatePercent": duplicatePercent})
+		return spec.ReturnSuccess(string(duplicateJson))
+	} else {
+		return spec.ResponseFailWithFlags(spec.PingSelfVerifyFailed, params.experimentType, fmt.Sprintf("%d", params.expectedPercent), fmt.Sprintf("%.2f", duplicatePercent))
+	}
+}
+
+func (npe *NetworkPingExecutor) onReorder(ctx context.Context, params *PingParams) *spec.Response {
+	interval, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(params.duration)/float64(params.quantity)), 64)
+	response := npe.channel.Run(ctx, "ping", fmt.Sprintf(`%s -i %.2f -c %d -A | grep "icmp_seq" | awk -F '[ =]' '{print $6}'`,
+		params.destinationIp, interval, params.quantity))
+	if !response.Success {
+		return spec.ReturnFail(spec.OsCmdExecFailed, response.Err)
+	}
+
+	var reorderPacketCount int
+	seqList := strings.Split(strings.TrimSpace(response.Result.(string)), "\n")
+
+	var maxSeq int
+	for _, seqStr := range seqList {
+		if seq, err := strconv.Atoi(strings.TrimSpace(seqStr)); err != nil {
+			return spec.ReturnFail(spec.OsCmdExecFailed, err.Error())
+		} else {
+			if seq > maxSeq {
+				maxSeq = seq
+			} else {
+				reorderPacketCount++
+			}
+		}
+	}
+
+	reorderPercent := float64(reorderPacketCount) * 100 / float64(params.quantity)
+	if checkPercent(reorderPercent, params.expectedPercent, params.tolerance) {
+		reorderJson, _ := json.Marshal(map[string]float64{"reorderPercent": reorderPercent})
+		return spec.ReturnSuccess(string(reorderJson))
+	} else {
+		return spec.ResponseFailWithFlags(spec.PingSelfVerifyFailed, params.experimentType,
+			fmt.Sprintf("%d", params.expectedPercent), fmt.Sprintf("%.2f", reorderPercent))
+	}
+}
+
+func (npe *NetworkPingExecutor) onCorrupt(ctx context.Context, params *PingParams) *spec.Response {
+	interval, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(params.duration)/float64(params.quantity)), 64)
+	response := npe.channel.Run(ctx, "ping", fmt.Sprintf(`%s -i %.2f -c %d -A | grep "icmp_seq" | grep "%s" | wc -l`,
+		params.destinationIp, interval, params.quantity, params.destinationIp))
+	if !response.Success {
+		return spec.ReturnFail(spec.OsCmdExecFailed, response.Err)
+	}
+
+	if receivedPacketCount, err := strconv.Atoi(strings.TrimSpace(response.Result.(string))); err != nil {
+		return spec.ReturnFail(spec.OsCmdExecFailed, err.Error())
+	} else {
+		corruptPercent := float64(params.quantity-receivedPacketCount) * 100 / float64(params.quantity)
+		if checkPercent(corruptPercent, params.expectedPercent, params.tolerance) {
+			corruptJson, _ := json.Marshal(map[string]float64{"corruptPercent": corruptPercent})
+			return spec.ReturnSuccess(string(corruptJson))
+		} else {
+			return spec.ResponseFailWithFlags(spec.PingSelfVerifyFailed, params.experimentType,
+				fmt.Sprintf("%d", params.expectedPercent), fmt.Sprintf("%.2f", corruptPercent))
+		}
+	}
+}
+
+func (npe *NetworkPingExecutor) onLoss(ctx context.Context, params *PingParams) *spec.Response {
+	interval, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", float64(params.duration)/float64(params.quantity)), 64)
+	response := npe.channel.Run(ctx, "ping", fmt.Sprintf(`%s -i %.2f -c %d | grep "packet loss"`,
+		params.destinationIp, interval, params.quantity))
+	if !response.Success {
+		return spec.ReturnFail(spec.OsCmdExecFailed, response.Err)
+	}
+
+	reg := regexp.MustCompile(`,[^,]+,\s(.+)% packet loss`)
+	lossStr := reg.FindAllStringSubmatch(response.Result.(string), -1)[0][1]
+	if lossStr == "" {
+		return spec.ReturnFail(spec.OsCmdExecFailed, "Failed to obtain packet loss rate by ping")
+	}
+	lossPercent, _ := strconv.ParseFloat(strings.TrimSpace(lossStr), 64)
+	if checkPercent(lossPercent, params.expectedPercent, params.tolerance) {
+		lossJson, _ := json.Marshal(map[string]float64{"lossPercent": lossPercent})
+		return spec.ReturnSuccess(string(lossJson))
+	} else {
+		return spec.ResponseFailWithFlags(spec.PingSelfVerifyFailed, params.experimentType,
+			fmt.Sprintf("%d", params.expectedPercent), fmt.Sprintf("%.2f", lossPercent))
+	}
+}

--- a/exec/network/network_ping.go
+++ b/exec/network/network_ping.go
@@ -52,7 +52,7 @@ func NewPingActionSpec() spec.ExpActionCommandSpec {
 				},
 				&spec.ExpFlag{
 					Name:     "type",
-					Desc:     "Type",
+					Desc:     "Type, Optional value: loss, duplicate, reorder, corrupt, delay",
 					Required: true,
 				},
 				&spec.ExpFlag{

--- a/exec/network/network_send.go
+++ b/exec/network/network_send.go
@@ -33,7 +33,8 @@ func (t *TCPClient) Send(ctx context.Context, str string) bool {
 }
 
 func NewTCPClient(addr string) (*TCPClient, error) {
-	conn, err := net.Dial("tcp", addr)
+	dialer := net.Dialer{Timeout: 20 * time.Second}
+	conn, err := dialer.Dial("tcp", addr)
 	return &TCPClient{conn: conn}, err
 }
 

--- a/exec/network/network_send.go
+++ b/exec/network/network_send.go
@@ -1,0 +1,209 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/network/tc"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"net"
+	"strconv"
+	"time"
+)
+
+var SendNetworkBin = "chaos_send"
+
+type SendActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+type TCPClient struct {
+	conn net.Conn
+}
+
+func (t *TCPClient) Send(ctx context.Context, str string) bool {
+	n, err := t.conn.Write([]byte(str))
+	if err != nil || n <= 0 {
+		log.Errorf(ctx, "TCP Client Send Error: %v\n", err)
+		fmt.Println(ctx, "TCP Client Send Error: %v\n", err)
+		return false
+	}
+	return true
+}
+
+func NewTCPClient(addr string) (*TCPClient, error) {
+	conn, err := net.Dial("tcp", addr)
+	return &TCPClient{conn: conn}, err
+}
+
+func NewSendActionSpec() spec.ExpActionCommandSpec {
+	return &SendActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "destination-ip",
+					Desc:     "Destination ip",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "remote-port",
+					Desc:     "Remote port",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "quantity",
+					Desc:     "Quantity",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     "type",
+					Desc:     "Type, Optional value: loss, duplicate, reorder, corrupt, delay",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     "duration",
+					Desc:     "Sending time, decide how long to send these data packets",
+					Required: false,
+				},
+			},
+			ActionExecutor: &NetworkSendExecutor{},
+			ActionExample: `
+# Send tcp packets to verify network tc
+blade verify network send --destination-ip 127.0.0.1 --remote-port 9001 --quantity 100 --type loss
+blade verify network send --destination-ip 127.0.0.1 --remote-port 9001 --quantity 100 --type delay`,
+			ActionPrograms:   []string{SendNetworkBin},
+			ActionCategories: []string{category.SystemNetwork},
+		},
+	}
+}
+
+func (*SendActionSpec) Name() string {
+	return "send"
+}
+
+func (*SendActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*SendActionSpec) ShortDesc() string {
+	return "Send tcp packets"
+}
+
+func (s *SendActionSpec) LongDesc() string {
+	if s.ActionLongDesc != "" {
+		return s.ActionLongDesc
+	}
+	return "Send tcp packets"
+}
+
+type NetworkSendExecutor struct {
+	channel spec.Channel
+}
+
+func (nse *NetworkSendExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		log.Errorf(ctx, "Send only supports create or verify")
+		return spec.ReturnFail(spec.CommandIllegal, "Send only supports create or verify")
+	}
+
+	var duration int
+	var quantity int
+	var err error
+	destinationIp := model.ActionFlags["destination-ip"]
+	remotePort := model.ActionFlags["remote-port"]
+	quantityStr := model.ActionFlags["quantity"]
+	durationStr := model.ActionFlags["duration"]
+	sendType := model.ActionFlags["type"]
+
+	if sendType != tc.Loss && sendType != tc.Duplicate && sendType != tc.Reorder && sendType != tc.Corrupt && sendType != tc.Delay {
+		log.Errorf(ctx, "`%s`: type is illegal, it must be (loss | duplicate | reorder | corrupt | delay)", sendType)
+		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "type", sendType,
+			"it must be (loss | duplicate | reorder | corrupt | delay)")
+	}
+	if destinationIp == "" {
+		log.Errorf(ctx, "destination-ip is nil")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "destination-ip")
+	}
+	if remotePort == "" {
+		log.Errorf(ctx, "remote-port is nil")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "remote-port")
+	}
+	if quantityStr == "" {
+		quantity = -1
+	} else {
+		quantity, err = strconv.Atoi(quantityStr)
+		if err != nil {
+			log.Errorf(ctx, "`%s`: quantity is illegal, it must be a positive integer", quantityStr)
+			return spec.ResponseFailWithFlags(spec.ParameterIllegal, "quantity", quantityStr, "it must be a positive integer")
+		}
+	}
+
+	if durationStr != "" {
+		var err error
+		duration, err = strconv.Atoi(durationStr)
+		if err != nil {
+			log.Errorf(ctx, "`%s`: duration is illegal, it must be a positive integer", durationStr)
+			return spec.ResponseFailWithFlags(spec.ParameterIllegal, "duration", durationStr,
+				"it must be a positive integer")
+		}
+		if duration <= 0 {
+			log.Errorf(ctx, "`%s`: duration is illegal, it must be a positive integer and not less than 0", durationStr)
+			return spec.ResponseFailWithFlags(spec.ParameterIllegal, "duration", durationStr,
+				"it must be a positive integer and not less than 0")
+		}
+	} else {
+		duration = 3
+	}
+	return nse.start(ctx, destinationIp, remotePort, quantity, sendType, duration)
+}
+
+func (nse *NetworkSendExecutor) SetChannel(channel spec.Channel) {
+	nse.channel = channel
+}
+
+func (*NetworkSendExecutor) Name() string {
+	return "send"
+}
+
+func (nse *NetworkSendExecutor) start(ctx context.Context, ip string, port string, quantity int, sendType string, duration int) *spec.Response {
+	tcpClient, err := NewTCPClient(fmt.Sprintf("%s:%s", ip, port))
+	if err != nil {
+		log.Errorf(ctx, "TCP client init failed", err.Error())
+		return spec.ReturnFail(spec.TcpClientInitFailed, err.Error())
+	}
+
+	var intervalMs int
+	var count int
+	var msg string
+
+	if quantity == -1 {
+		intervalMs = 100
+		quantity = duration * 1000 / intervalMs
+	} else {
+		intervalMs = int(float64(duration) / float64(quantity) * 1000)
+	}
+	if sendType != tc.Delay {
+		msg = generateHandShakeMsg()
+	} else {
+		msg = generateTimeStampMsg()
+	}
+
+	for i := 0; i < quantity; i++ {
+		if tcpClient.Send(ctx, msg) {
+			count++
+		}
+		time.Sleep(time.Duration(intervalMs) * time.Millisecond)
+	}
+
+	return spec.ReturnSuccess(count)
+}
+
+func generateTimeStampMsg() string {
+	return fmt.Sprintf("%s:%d", "chaos", time.Now().UnixNano()/1000000)
+}
+
+func generateHandShakeMsg() string {
+	return fmt.Sprintf("%s:%s %s", "chaos", SHAKEHAND, time.Now().UnixNano()/1000000)
+}

--- a/exec/network/tc/network_loss.go
+++ b/exec/network/tc/network_loss.go
@@ -94,7 +94,7 @@ func (nle *NetworkLossExecutor) Exec(uid string, ctx context.Context, model *spe
 	var dev = ""
 	if netInterface, ok := model.ActionFlags["interface"]; ok {
 		if netInterface == "" {
-			log.Errorf(ctx,"interface is nil")
+			log.Errorf(ctx, "interface is nil")
 			return spec.ResponseFailWithFlags(spec.ParameterLess, "interface")
 		}
 		dev = netInterface
@@ -121,7 +121,6 @@ func (nle *NetworkLossExecutor) start(netInterface, localPort, remotePort, exclu
 	ignorePeerPort, force bool, ctx context.Context) *spec.Response {
 	classRule := fmt.Sprintf("netem loss %s%%", percent)
 	return startNet(ctx, netInterface, classRule, localPort, remotePort, excludePort, destIp, excludeIp, force, ignorePeerPort, nle.channel)
-
 }
 
 func (nle *NetworkLossExecutor) stop(netInterface string, ctx context.Context) *spec.Response {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/chaosblade-io/chaosblade-spec-go v1.5.1-0.20220423030509-6d8dbd90b300
 	github.com/containerd/cgroups v1.0.2-0.20210605143700-23b51209bf7b
+	github.com/google/gopacket v1.1.19
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
 	github.com/shirou/gopsutil v3.21.6+incompatible
 	github.com/tklauser/go-sysconf v0.3.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/chaosblade-io/chaosblade-spec-go => ../chaosblade-spec-go

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c h1:aY2hhxLhjEAbfXOx2nRJxCXezC6CO2V/yN+OCr1srtk=
 github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
@@ -73,7 +75,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -104,6 +108,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 		}
 
 		ctx := context.Background()
-		if mode != spec.Create && mode != spec.Destroy {
+		if mode != spec.Create && mode != spec.Destroy && mode != spec.Verify {
 			exitAndPrint(spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("invalid parameter, %v", args)), 0)
 		}
 
@@ -113,6 +113,8 @@ func main() {
 		ctx = context.WithValue(ctx, spec.Uid, uid)
 		if mode == spec.Destroy {
 			ctx = spec.SetDestroyFlag(ctx, uid)
+		} else if mode == spec.Verify {
+			ctx = spec.SetVerifyFlag(ctx, uid)
 		}
 
 		if expModel.ActionFlags[model.DebugFlag.Name] == spec.True {


### PR DESCRIPTION
Signed-off-by: Icesource <gonghuajian.ghj@alibaba-inc.com>

PR:
 1. provide ```blade verify network dns/occupy``` commands
 2. provide ```blade verify network ping --type loss/reorder/duplicate/corrupt/delay ```commands 
