### PR TITLE
fix: Fix deleting multiple experiments when specifying uid.

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -29,13 +29,23 @@ var cl = channel.NewLocalChannel()
 
 // stop hang process
 func Destroy(ctx context.Context, c spec.Channel, action string) *spec.Response {
-	ctx = context.WithValue(ctx, channel.ProcessKey, action)
+	suid := ctx.Value(spec.Uid)
+	/* If suid is specified, it will be deleted exactly 
+	 * according to suid, otherwise it will be based on action. */
+	if suid != nil && suid != spec.UnknownUid {
+		ctx = context.WithValue(ctx, channel.ProcessKey, suid)
+	} else {
+		ctx = context.WithValue(ctx, channel.ProcessKey, action)
+	}
+
+	// Adapt to old versions.
 	originalBin := ctx.Value("bin")
 	pids := make([]string, 0)
 	if originalBin != nil {
 		originalPids, _ := cl.GetPidsByProcessName(originalBin.(string), ctx)
 		pids = append(pids, originalPids...)
 	}
+
 	ps, _ := cl.GetPidsByProcessName("chaos_os", ctx)
 	pids = append(ps, pids...)
 	if pids == nil || len(pids) == 0 {


### PR DESCRIPTION
Signed-off-by: Super-long <0x4f4f4f4f@gmail.com>

### Describe what this PR does / why we need it
Take the generated expblade create cpu fullload --cpu-count 1 as an example.

When we execute the blend destroy uid, chaosblade is actually chaos_os destroy cpu fullload --cpu-count=1 --uid=e39ebc941a451b15 sent to exec-os first

The behavior at this point is that chaosblade destroys all chaos-related experiences. The root of the problem comes from Destroy, which lacks a judgment on the suid when looking for the pid to be deleted.

So even if we specify the uid in destroy, all chaos-related experiments will actually be deleted.

Translated with www.DeepL.com/Translator (free version)

### Does this pull request fix one issue?

https://github.com/chaosblade-io/chaosblade/issues/46

### Describe how you did it

Add suid support for Destroy function.


### Special notes for reviews
One of the judgments in the added code is ”spec.UnknownUid“, which occurs when executing something like `blade destroy cpu fullload`, the uid will be set to "spec.UnknownUid" and we don't want to execute GetPidsByProcessName with "spec.UnknownUid".


