### PR TITLE
fix: Change the value pass in slope to a reference pass.

### DIFF
--- a/exec/cpu/cpu.go
+++ b/exec/cpu/cpu.go
@@ -282,7 +282,9 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount, cpuP
 		}
 	}
 
-	slope(ctx, cpuPercent, climbTime, slopePercent, precpu, cpuIndex)
+	// make CPU slowly climb to some level, to simulate slow resource competition 
+	// which system faults cannot be quickly noticed by monitoring system.
+	slope(ctx, cpuPercent, climbTime, &slopePercent, precpu, cpuIndex)
 
 	quota := make(chan int64, cpuCount)
 	for i := 0; i < cpuCount; i++ {
@@ -299,17 +301,17 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount, cpuP
 
 const period = int64(1000000000)
 
-func slope(ctx context.Context, cpuPercent int, climbTime int, slopePercent float64, precpu bool, cpuIndex int) {
+func slope(ctx context.Context, cpuPercent int, climbTime int, slopePercent *float64, precpu bool, cpuIndex int) {
 	if climbTime != 0 {
 		var ticker = time.NewTicker(time.Second)
-		slopePercent = getUsed(ctx, precpu, cpuIndex)
-		var startPercent = float64(cpuPercent) - slopePercent
+		*slopePercent = getUsed(ctx, precpu, cpuIndex)
+		var startPercent = float64(cpuPercent) - *slopePercent
 		go func() {
 			for range ticker.C {
-				if slopePercent < float64(cpuPercent) {
-					slopePercent += startPercent / float64(climbTime)
-				} else if slopePercent > float64(cpuPercent) {
-					slopePercent -= startPercent / float64(climbTime)
+				if *slopePercent < float64(cpuPercent) {
+					*slopePercent += startPercent / float64(climbTime)
+				} else if *slopePercent > float64(cpuPercent) {
+					*slopePercent -= startPercent / float64(climbTime)
 				}
 			}
 		}()


### PR DESCRIPTION
Signed-off-by: Super-long <0x4f4f4f4f@gmail.com>

### Describe what this PR does / why we need it
Currently, the slopePercent parameter in slope is passed as a value, and changes to slopePercent cannot be passed outside of slope, so this bug prevents `-climb-time` from taking effect.


### Describe how you did it

Change the value pass in slope to a reference pass.
