### PR TITLE
fix: fix cpu variable name precpu to perCpu

### DIFF
--- a/exec/cpu/cpu.go
+++ b/exec/cpu/cpu.go
@@ -271,9 +271,9 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount, cpuP
 	slopePercent := float64(cpuPercent)
 
 	var cpuIndex int
-	precpu := false
+	percpu := false
 	if cpuIndexStr != "" {
-		precpu = true
+		percpu = true
 		var err error
 		cpuIndex, err = strconv.Atoi(cpuIndexStr)
 		if err != nil {
@@ -282,15 +282,15 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount, cpuP
 		}
 	}
 
-	slope(ctx, cpuPercent, climbTime, slopePercent, precpu, cpuIndex)
+	slope(ctx, cpuPercent, climbTime, slopePercent, percpu, cpuIndex)
 
 	quota := make(chan int64, cpuCount)
 	for i := 0; i < cpuCount; i++ {
-		go burn(ctx, quota, slopePercent, precpu, cpuIndex)
+		go burn(ctx, quota, slopePercent, percpu, cpuIndex)
 	}
 
 	for {
-		q := getQuota(ctx, slopePercent, precpu, cpuIndex)
+		q := getQuota(ctx, slopePercent, percpu, cpuIndex)
 		for i := 0; i < cpuCount; i++ {
 			quota <- q
 		}
@@ -299,10 +299,10 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount, cpuP
 
 const period = int64(1000000000)
 
-func slope(ctx context.Context, cpuPercent int, climbTime int, slopePercent float64, precpu bool, cpuIndex int) {
+func slope(ctx context.Context, cpuPercent int, climbTime int, slopePercent float64, percpu bool, cpuIndex int) {
 	if climbTime != 0 {
 		var ticker = time.NewTicker(time.Second)
-		slopePercent = getUsed(ctx, precpu, cpuIndex)
+		slopePercent = getUsed(ctx, percpu, cpuIndex)
 		var startPercent = float64(cpuPercent) - slopePercent
 		go func() {
 			for range ticker.C {
@@ -316,16 +316,16 @@ func slope(ctx context.Context, cpuPercent int, climbTime int, slopePercent floa
 	}
 }
 
-func getQuota(ctx context.Context, slopePercent float64, precpu bool, cpuIndex int) int64 {
-	used := getUsed(ctx, precpu, cpuIndex)
-	log.Debugf(ctx, "cpu usage: %f , precpu: %v, cpuIndex %d", used, precpu, cpuIndex)
+func getQuota(ctx context.Context, slopePercent float64, percpu bool, cpuIndex int) int64 {
+	used := getUsed(ctx, percpu, cpuIndex)
+	log.Debugf(ctx, "cpu usage: %f , percpu: %v, cpuIndex %d", used, percpu, cpuIndex)
 	dx := (slopePercent - used) / 100
 	busy := int64(dx * float64(period))
 	return busy
 }
 
-func burn(ctx context.Context, quota <-chan int64, slopePercent float64, precpu bool, cpuIndex int) {
-	q := getQuota(ctx, slopePercent, precpu, cpuIndex)
+func burn(ctx context.Context, quota <-chan int64, slopePercent float64, percpu bool, cpuIndex int) {
+	q := getQuota(ctx, slopePercent, percpu, cpuIndex)
 	ds := period - q
 	if ds < 0 {
 		ds = 0

--- a/exec/cpu/cpu_darwin.go
+++ b/exec/cpu/cpu_darwin.go
@@ -23,13 +23,13 @@ import (
 	"time"
 )
 
-func getUsed(ctx context.Context, precpu bool, cpuIndex int) float64 {
-	totalCpuPercent, err := cpu.Percent(time.Second, precpu)
+func getUsed(ctx context.Context, percpu bool, cpuIndex int) float64 {
+	totalCpuPercent, err := cpu.Percent(time.Second, percpu)
 	if err != nil {
 		log.Fatalf(ctx, "get cpu usage fail, %s", err.Error())
 	}
-	if precpu {
-		if cpuIndex > len(totalCpuPercent){
+	if percpu {
+		if cpuIndex > len(totalCpuPercent) {
 			log.Fatalf(ctx, "illegal cpu index %d", cpuIndex)
 		}
 		return totalCpuPercent[cpuIndex]

--- a/exec/cpu/cpu_linux.go
+++ b/exec/cpu/cpu_linux.go
@@ -27,7 +27,7 @@ import (
 	"time"
 )
 
-func getUsed(ctx context.Context, precpu bool, cpuIndex int) float64 {
+func getUsed(ctx context.Context, percpu bool, cpuIndex int) float64 {
 
 	pid := ctx.Value(channel.NSTargetFlagName)
 	cpuCount := ctx.Value("cpuCount").(int)
@@ -66,12 +66,12 @@ func getUsed(ctx context.Context, precpu bool, cpuIndex int) float64 {
 		}
 	}
 
-	totalCpuPercent, err := cpu.Percent(time.Second, precpu)
+	totalCpuPercent, err := cpu.Percent(time.Second, percpu)
 	if err != nil {
 		log.Fatalf(ctx, "get cpu usage fail, %s", err.Error())
 	}
-	if precpu {
-		if cpuIndex > len(totalCpuPercent){
+	if percpu {
+		if cpuIndex > len(totalCpuPercent) {
 			log.Fatalf(ctx, "illegal cpu index %d", cpuIndex)
 		}
 		return totalCpuPercent[cpuIndex]


### PR DESCRIPTION
The cpu.Percent returns an array when percpu is true and a single value when percpu is false.
Its semantics should be per CPU instead of previous CPU