### PR TITLE
fix: fix cpu exp destroy mode when suid is empty

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -30,9 +30,9 @@ var cl = channel.NewLocalChannel()
 // stop hang process
 func Destroy(ctx context.Context, c spec.Channel, action string) *spec.Response {
 	suid := ctx.Value(spec.Uid)
-	/* If suid is specified, it will be deleted exactly 
+	/* If suid is specified, it will be deleted exactly
 	 * according to suid, otherwise it will be based on action. */
-	if suid != nil && suid != spec.UnknownUid {
+	if suid != nil && suid != spec.UnknownUid && suid != "" {
 		ctx = context.WithValue(ctx, channel.ProcessKey, suid)
 	} else {
 		ctx = context.WithValue(ctx, channel.ProcessKey, action)

--- a/main.go
+++ b/main.go
@@ -106,13 +106,14 @@ func main() {
 		}
 
 		uid := expModel.ActionFlags[model.UidFlag.Name]
-		if uid == "" {
-			uid, _ = util.GenerateUid()
-		}
 
 		ctx = context.WithValue(ctx, spec.Uid, uid)
 		if mode == spec.Destroy {
 			ctx = spec.SetDestroyFlag(ctx, uid)
+		} else {
+			if uid == "" {
+				uid, _ = util.GenerateUid()
+			}
 		}
 
 		if expModel.ActionFlags[model.DebugFlag.Name] == spec.True {


### PR DESCRIPTION
Signed-off-by: Icesource <gonghuajian.ghj@alibaba-inc.com>

For https://github.com/chaosblade-io/chaosblade/issues/46

when exp is destroy mode, suid is always generated randomly. But suid is not required in destroy mode. And it also causes the wrong suid to be specified when destroying the Cpu scene.