### PR TITLE
feature: made process kill and stop support --pid flag

### DIFF
--- a/exec/process/process_kill.go
+++ b/exec/process/process_kill.go
@@ -58,6 +58,10 @@ func NewKillProcessActionCommandSpec() spec.ExpActionCommandSpec {
 					Name: "exclude-process",
 					Desc: "Exclude process",
 				},
+				&spec.ExpFlag{
+					Name: "pid",
+					Desc: "pid",
+				},
 			},
 			ActionFlags:    []spec.ExpFlagSpec{},
 			ActionExecutor: &KillProcessExecutor{},

--- a/exec/process/process_stop.go
+++ b/exec/process/process_stop.go
@@ -57,6 +57,10 @@ func NewStopProcessActionCommandSpec() spec.ExpActionCommandSpec {
 					Name: "exclude-process",
 					Desc: "Exclude process",
 				},
+				&spec.ExpFlag{
+					Name: "pid",
+					Desc: "pid",
+				},
 			},
 			ActionFlags:    []spec.ExpFlagSpec{},
 			ActionExecutor: &StopProcessExecutor{},


### PR DESCRIPTION
Signed-off-by: EdisonX-sudo [387617982@qq.com](mailto:387617982@qq.com)

### Describe what this PR does / why we need it

feature: made process kill and stop support --pid flag
in some occasion, we still need to kill or stop process by declaring a specified pid explicitly

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
create process kill --signal 9 --pid 1227
create process stop --pid 1227

### Special notes for reviews
