### PR TITLE
feat: add time travel experiment

### DIFF
--- a/build/spec.go
+++ b/build/spec.go
@@ -27,6 +27,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/process"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/script"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/systemd"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/time"
 	"log"
 	"os"
 
@@ -57,6 +58,7 @@ func getModels() *spec.Models {
 		file.NewFileCommandSpec(),
 		kernel.NewKernelInjectCommandSpec(),
 		systemd.NewSystemdCommandModelSpec(),
+		time.NewTimeCommandSpec(),
 	}
 	specModels := make([]*spec.Models, 0)
 	for _, modeSpec := range modelCommandSpecs {

--- a/exec/model/model_linux.go
+++ b/exec/model/model_linux.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/process"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/script"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/systemd"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/time"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 )
 
@@ -42,5 +43,6 @@ func GetAllExpModels() []spec.ExpModelCommandSpec {
 		file.NewFileCommandSpec(),
 		kernel.NewKernelInjectCommandSpec(),
 		systemd.NewSystemdCommandModelSpec(),
+		time.NewTimeCommandSpec(),
 	}
 }

--- a/exec/time/time.go
+++ b/exec/time/time.go
@@ -14,18 +14,35 @@
  * limitations under the License.
  */
 
-package category
+package time
 
-const (
-	System        = "system"
-	SystemCpu     = "system_cpu"
-	SystemMem     = "system_mem"
-	SystemDisk    = "system_disk"
-	SystemNetwork = "system_network"
-	SystemProcess = "system_process"
-	SystemScript  = "system_script"
-	SystemFile    = "system_file"
-	SystemKernel  = "system_kernel"
-	SystemSystemd = "system_systemd"
-	SystemTime    = "system_time"
+import (
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 )
+
+type TimeCommandSpec struct {
+	spec.BaseExpModelCommandSpec
+}
+
+func NewTimeCommandSpec() spec.ExpModelCommandSpec {
+	return &TimeCommandSpec{
+		spec.BaseExpModelCommandSpec{
+			ExpFlags: []spec.ExpFlagSpec{},
+			ExpActions: []spec.ExpActionCommandSpec{
+				NewTravelTimeActionCommandSpec(),
+			},
+		},
+	}
+}
+
+func (*TimeCommandSpec) Name() string {
+	return "time"
+}
+
+func (*TimeCommandSpec) ShortDesc() string {
+	return "Time experiment"
+}
+
+func (*TimeCommandSpec) LongDesc() string {
+	return "Time experiment"
+}

--- a/exec/time/time_travel.go
+++ b/exec/time/time_travel.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package time
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+)
+
+const TravelTimeBin = "chaos_timetravel"
+
+type TravelTimeActionCommandSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewTravelTimeActionCommandSpec() spec.ExpActionCommandSpec {
+	return &TravelTimeActionCommandSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name: "offset",
+					Desc: "Travel time offset, for example: -1d2h3m50s",
+				},
+				&spec.ExpFlag{
+					Name: "disableNtp",
+					Desc: "Whether to disable Network Time Protocol to synchronize time",
+				},
+			},
+			ActionExecutor: &TravelTimeExecutor{},
+			ActionExample: `
+# Time travel 5 minutes and 30 seconds into the future
+blade create time travel --offset 5m30s
+`,
+			ActionPrograms:   []string{TravelTimeBin},
+			ActionCategories: []string{category.SystemTime},
+		},
+	}
+}
+
+func (*TravelTimeActionCommandSpec) Name() string {
+	return "travel"
+}
+
+func (*TravelTimeActionCommandSpec) Aliases() []string {
+	return []string{"k"}
+}
+
+func (*TravelTimeActionCommandSpec) ShortDesc() string {
+	return "Time Travel"
+}
+
+func (k *TravelTimeActionCommandSpec) LongDesc() string {
+	if k.ActionLongDesc != "" {
+		return k.ActionLongDesc
+	}
+	return "Modify system time to fake processes"
+}
+
+func (*TravelTimeActionCommandSpec) Categories() []string {
+	return []string{category.SystemProcess}
+}
+
+type TravelTimeExecutor struct {
+	channel spec.Channel
+}
+
+func (tte *TravelTimeExecutor) Name() string {
+	return "travel"
+}
+
+func (tte *TravelTimeExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	commands := []string{"date", "timedatectl"}
+	if response, ok := tte.channel.IsAllCommandsAvailable(ctx, commands); !ok {
+		return response
+	}
+
+	var disableNtp bool
+	timeOffsetStr := model.ActionFlags["offset"]
+	disableNtpStr := model.ActionFlags["disableNtp"]
+
+	if timeOffsetStr == "" {
+		log.Errorf(ctx, "offset is nil")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "offset")
+	}
+	disableNtp = disableNtpStr == "true" || disableNtpStr == ""
+
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return tte.stop(ctx)
+	}
+
+	return tte.start(ctx, timeOffsetStr, disableNtp)
+}
+
+func (tte *TravelTimeExecutor) SetChannel(channel spec.Channel) {
+	tte.channel = channel
+}
+
+func (tte *TravelTimeExecutor) stop(ctx context.Context) *spec.Response {
+	response := tte.channel.Run(ctx, "timedatectl", fmt.Sprintf(`set-ntp true`))
+	if !response.Success {
+		return response
+	}
+	return tte.channel.Run(ctx, "hwclock", fmt.Sprintf(`--hctosys`))
+}
+
+func (tte *TravelTimeExecutor) start(ctx context.Context, timeOffsetStr string, disableNtp bool) *spec.Response {
+	duration, err := time.ParseDuration(timeOffsetStr)
+	if err != nil {
+		log.Errorf(ctx, "offset is invalid")
+		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "offset", timeOffsetStr, err)
+	}
+	targetTime := time.Now().Add(duration).Format("01/02/2006 15:04:05")
+
+	if disableNtp {
+		response := tte.channel.Run(ctx, "timedatectl", fmt.Sprintf(`set-ntp false`))
+		if !response.Success {
+			return response
+		}
+	}
+
+	return tte.channel.Run(ctx, "date", fmt.Sprintf(`-s "%s" `, targetTime))
+}


### PR DESCRIPTION
Signed-off-by: Icesource <gonghuajian.ghj@alibaba-inc.com>

### Describe what this PR does / why we need it
新增Time Travel故障类型，可修改系统时间

时钟偏移可以让节点看到的系统时间出现偏移，验证分布式系统下依赖于时间同步的逻辑是否会由于单点时间异常而出现异常
例如验证Mysql主从复制下，会不会由于从节点时间错误导致数据不一致
或者分布式数据库的时钟一致性能否在节点系统时间异常的情况下正常工作

### Describe how you did it
执行date命令修改系统时间，销毁则通过hwclock将硬件时钟同步到系统时间
TODO：date指令仅能粗粒度修改系统时间，之后需要探索实现容器进程维度修改时间的方法

### Describe how to verify it
time travel 至 10m30s之后
```
date
2022年 08月 25日 星期四 15:36:06 CST

./target/chaosblade-1.6.1/bin/chaos_os create time travel --offset 10m30s
{"code":200,"success":true,"result":"2022年 08月 25日 星期四 15:47:08 CST\n"}
// 系统时间修改为了10分30秒之后，执行chaos_os destroy time travel --offset 10m30s可恢复

./target/chaosblade-1.6.1/bin/chaos_os create time travel --offset -4m27s
{"code":200,"success":true,"result":"2022年 08月 25日 星期四 15:34:22 CST\n"}
// 系统时间修改为了4分27秒之前
```
