### PR TITLE
Fix variable name error, from precpu to percpu.

### DIFF
--- a/exec/cpu/cpu.go
+++ b/exec/cpu/cpu.go
@@ -284,7 +284,7 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount, cpuP
 
 	// make CPU slowly climb to some level, to simulate slow resource competition 
 	// which system faults cannot be quickly noticed by monitoring system.
-	slope(ctx, cpuPercent, climbTime, &slopePercent, precpu, cpuIndex)
+	slope(ctx, cpuPercent, climbTime, &slopePercent, percpu, cpuIndex)
 
 	quota := make(chan int64, cpuCount)
 	for i := 0; i < cpuCount; i++ {
@@ -301,10 +301,10 @@ func (ce *cpuExecutor) start(ctx context.Context, cpuList string, cpuCount, cpuP
 
 const period = int64(1000000000)
 
-func slope(ctx context.Context, cpuPercent int, climbTime int, slopePercent *float64, precpu bool, cpuIndex int) {
+func slope(ctx context.Context, cpuPercent int, climbTime int, slopePercent *float64, percpu bool, cpuIndex int) {
 	if climbTime != 0 {
 		var ticker = time.NewTicker(time.Second)
-		*slopePercent = getUsed(ctx, precpu, cpuIndex)
+		*slopePercent = getUsed(ctx, percpu, cpuIndex)
 		var startPercent = float64(cpuPercent) - *slopePercent
 		go func() {
 			for range ticker.C {

--- a/exec/process/process.go
+++ b/exec/process/process.go
@@ -133,11 +133,8 @@ func getPids(ctx context.Context, cl spec.Channel, model *spec.ExpModel, uid str
 			return spec.ReturnFail(spec.ParameterIllegal, fmt.Sprintf("illegal parameter ports, %v", err))
 		}
 	} else if pid != "" {
-		if strings.Contains(pid, ",") {
-			pids = strings.Split(pid, ",")
-		} else {
-			pids = append(pids, pid)
-		}
+		tempPidList := strings.Split(pid, ",")
+		pids = append(pids, tempPidList...)
 	}
 	if pids == nil || len(pids) == 0 {
 		if ignoreProcessNotFound {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fix variable name.

### Describe how you did it


### Describe how to verify it
Run make build_linux will failed by error `exec/cpu/cpu.go:287:51: undefined: precpu`

### Special notes for reviews
In `exec/cpu/cpu.go` variable `percpu` name not consistent, both `percpu` and `precpu`