### PR TITLE
fix：the file append experiment is unreasonable

### DIFF
--- a/exec/file/file_append.go
+++ b/exec/file/file_append.go
@@ -54,7 +54,7 @@ func NewFileAppendActionSpec() spec.ExpActionCommandSpec {
 				},
 				&spec.ExpFlag{
 					Name: "interval",
-					Desc: "append interval, must be a positive integer, default 1s",
+					Desc: "append interval, must be a positive integer",
 				},
 				&spec.ExpFlag{
 					Name:   "escape",
@@ -137,8 +137,8 @@ func (f *FileAppendActionExecutor) Exec(uid string, ctx context.Context, model *
 
 	// default 1
 	count := 1
-	// 1000 ms
-	interval := 1
+	// default 0
+	interval := 0
 
 	content := model.ActionFlags["content"]
 	countStr := model.ActionFlags["count"]
@@ -172,7 +172,10 @@ func (f *FileAppendActionExecutor) start(filepath string, content string, count 
 	if !response.Success {
 		return response
 	}
-
+	// Without interval, it will not be executed regularly.
+	if interval < 1 {
+		return nil
+	}
 	ticker := time.NewTicker(time.Second * time.Duration(interval))
 	for range ticker.C {
 		response := appendFile(f.channel, count, ctx, content, filepath, escape, enableBase64)

--- a/exec/systemd/systemd_stop.go
+++ b/exec/systemd/systemd_stop.go
@@ -91,14 +91,13 @@ func (sse *StopSystemdExecutor) Exec(uid string, ctx context.Context, model *spe
 		return spec.ResponseFailWithFlags(spec.ParameterLess, "service")
 	}
 
-	flags := fmt.Sprintf("--service %s", service)
 	if _, ok := spec.IsDestroy(ctx); ok {
 		return sse.startService(service, ctx)
 	} else {
 		if response := checkServiceInvalid(uid, service, ctx, sse.channel); response != nil {
 			return response
 		}
-		return sse.channel.Run(ctx, path.Join(sse.channel.GetScriptPath(), StopSystemdBin), flags)
+		return sse.channel.Run(ctx, "systemctl", fmt.Sprintf("stop %s", service))
 	}
 }
 


### PR DESCRIPTION

### Describe what this PR does / why we need it

This PR will fix the bug: the file append experiment is unreasonable.


### Does this pull request fix one issue?

[bug report： the file append experiment is unreasonable #824](https://github.com/chaosblade-io/chaosblade/issues/824)

This PR contains another pr that has not been merged:
[fix: failed to create the systemd experiment #147](https://github.com/chaosblade-io/chaosblade-exec-os/pull/147)

### Describe how you did it
Without interval parameter, it will not be executed regularly.

### Describe how to verify it

1.Build a new chaos_os in the chaosblade-exec-os

`cd chaosblade-exec-os`
`make build_linux (on the Mac operating system)`
`cd  target/chaosblade-1.7.0/bin`

2.Move the new chaos_os to the chaosblade-1.7.0 from the chaosblade-exec-os

`scp chaos_os root@x.x.x.x:/root/chaosblade-1.7.0`

3.Replace the old chaos_os

`ssh root@x.x.x.x`
`cd chaosblade-1.7.0/bin`
`mv chaos_os chaos_os_old`
`cd ..`
`mv chaos_os bin/chaos_os`

4.create a file append experiment
`touch /root/test.log `
`./blade create file append --filepath=/root/test.log --content="HELL WORLD"`
`tail -10f /root/test.log `

### Special notes for reviews
This PR contains another pr that has not been merged:
[fix: failed to create the systemd experiment #147](https://github.com/chaosblade-io/chaosblade-exec-os/pull/147)
