### PR TITLE
fix: Remove unused import pkg path

### DIFF
--- a/exec/systemd/systemd_stop.go
+++ b/exec/systemd/systemd_stop.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/chaosblade-io/chaosblade-spec-go/log"
-	"path"
 
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Remove the unused import pkg path in `exec/systemd/systemd_stop.go`

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
