### PR TITLE
fix: parameter auto-create-dir  is invalid. move file check dir exists before  autoCre…

### DIFF
--- a/exec/file/file_move.go
+++ b/exec/file/file_move.go
@@ -112,19 +112,14 @@ func (f *FileMoveActionExecutor) Exec(uid string, ctx context.Context, model *sp
 		return f.stop(filepath, target, ctx)
 	}
 
-	if !exec.CheckFilepathExists(ctx, f.channel, target) {
-		log.Errorf(ctx, "`%s`: target dir does not exist", filepath)
-		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "target", target, "the file does not exist")
-	}
-
 	force := model.ActionFlags["force"] == "true"
 	autoCreateDir := model.ActionFlags["auto-create-dir"] == "true"
 
 	if !force {
 		targetFile := path.Join(target, "/", path.Base(filepath))
 		if exec.CheckFilepathExists(ctx, f.channel, targetFile) {
-			log.Errorf(ctx, "`%s`: target file does not exist", targetFile)
-			return spec.ResponseFailWithFlags(spec.ParameterInvalid, "target", targetFile, "the target file does not exist")
+			log.Errorf(ctx, "`%s`: target file already exists", targetFile)
+			return spec.ResponseFailWithFlags(spec.ParameterInvalid, "target", targetFile, "the target file already exists")
 		}
 	}
 	return f.start(filepath, target, force, autoCreateDir, ctx)


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
fix: parameter auto-create-dir is invalid. move file check dir exists before  autoCreateDir used. issue（#898）

修改如下：
 1、删除在使用autoCreateDir前的对target目录是否存在的验证逻辑
2、修改当使用force参数但target目录存在该文件时的错误日志和提示信息



### Does this pull request fix one issue?
for issue: https://github.com/chaosblade-io/chaosblade/issues/898


<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
修改如下：
 1、删除在使用autoCreateDir前的对target目录是否存在的验证逻辑
2、修改当使用force参数但target目录存在该文件时的错误日志和提示信息



### Describe how to verify it


### Special notes for reviews
