### PR TITLE
Bugfix: Fix destory process load scenario error

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -19,9 +19,10 @@ package exec
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/chaosblade-io/chaosblade-spec-go/channel"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
-	"strings"
 )
 
 // todo
@@ -48,9 +49,10 @@ func Destroy(ctx context.Context, c spec.Channel, action string) *spec.Response 
 
 	ps, _ := cl.GetPidsByProcessName(spec.ChaosOsBin, ctx)
 	pids = append(ps, pids...)
-	if pids == nil || len(pids) == 0 {
-		sprintf := fmt.Sprintf("destory experiment failed, cannot get the chaos_os program")
-		return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
+	if len(pids) == 0 {
+		// If no processes found, consider the destroy operation successful
+		// This can happen when processes have already been cleaned up or never existed
+		return spec.ReturnSuccess("no processes found to destroy")
 	}
 	return cl.Run(ctx, "kill", fmt.Sprintf(`-9 %s`, strings.Join(pids, " ")))
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix https://github.com/chaosblade-io/chaosblade/issues/1138

### Describe how you did it
The ping process has been properly cleared during the destory process, so there is no need to clear the chaos_os process. Therefore, if the chaos_os process cannot be found during the destory process, a success message is returned.

### Describe how to verify it

```
# ./blade c process load --count 10 -d
{"code":200,"success":true,"result":"342e0edd01cb14a6"}

# ./blade d 342e0edd01cb14a6
{"code":200,"success":true,"result":{"target":"process","action":"load","flags":{"count":"10","debug":"true"},"ActionProcessHang":false}}

# ps -ef | grep ping
root     3613929 3585100  0 20:54 pts/0    00:00:00 grep --color=auto ping
```

### Special notes for reviews
