### PR TITLE
Feature: Enhance time travel scene compatibility

### DIFF
--- a/exec/time/time_travel.go
+++ b/exec/time/time_travel.go
@@ -19,6 +19,7 @@ package time
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
@@ -43,13 +44,19 @@ func NewTravelTimeActionCommandSpec() spec.ExpActionCommandSpec {
 				},
 				&spec.ExpFlag{
 					Name: "disableNtp",
-					Desc: "Whether to disable Network Time Protocol to synchronize time",
+					Desc: "Whether to disable Network Time Protocol to synchronize time (default: true, set to false if NTP is not supported)",
 				},
 			},
 			ActionExecutor: &TravelTimeExecutor{},
 			ActionExample: `
 # Time travel 5 minutes and 30 seconds into the future
 blade create time travel --offset 5m30s
+
+# Time travel without disabling NTP (useful when NTP is not supported)
+blade create time travel --offset 5m30s --disableNtp false
+
+# Time travel backward 2 hours and 30 minutes
+blade create time travel --offset -2h30m
 `,
 			ActionPrograms:   []string{TravelTimeBin},
 			ActionCategories: []string{category.SystemTime},
@@ -73,7 +80,7 @@ func (k *TravelTimeActionCommandSpec) LongDesc() string {
 	if k.ActionLongDesc != "" {
 		return k.ActionLongDesc
 	}
-	return "Modify system time to fake processes"
+	return "Modify system time to fake processes. Supports multiple time formats and gracefully handles systems without timedatectl or NTP support."
 }
 
 func (*TravelTimeActionCommandSpec) Categories() []string {
@@ -89,10 +96,15 @@ func (tte *TravelTimeExecutor) Name() string {
 }
 
 func (tte *TravelTimeExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
-	commands := []string{"date", "timedatectl"}
+	// Check for available time modification commands
+	commands := []string{"date"}
 	if response, ok := tte.channel.IsAllCommandsAvailable(ctx, commands); !ok {
 		return response
 	}
+
+	// Check if timedatectl is available (optional)
+	timedatectlAvailable := tte.channel.IsCommandAvailable(ctx, "timedatectl")
+	log.Infof(ctx, "timedatectl available: %v", timedatectlAvailable)
 
 	var disableNtp bool
 	timeOffsetStr := model.ActionFlags["offset"]
@@ -105,38 +117,100 @@ func (tte *TravelTimeExecutor) Exec(uid string, ctx context.Context, model *spec
 	disableNtp = disableNtpStr == "true" || disableNtpStr == ""
 
 	if _, ok := spec.IsDestroy(ctx); ok {
-		return tte.stop(ctx)
+		return tte.stop(ctx, timedatectlAvailable)
 	}
 
-	return tte.start(ctx, timeOffsetStr, disableNtp)
+	return tte.start(ctx, timeOffsetStr, disableNtp, timedatectlAvailable)
 }
 
 func (tte *TravelTimeExecutor) SetChannel(channel spec.Channel) {
 	tte.channel = channel
 }
 
-func (tte *TravelTimeExecutor) stop(ctx context.Context) *spec.Response {
-	response := tte.channel.Run(ctx, "timedatectl", `set-ntp true`)
-	if !response.Success {
-		return response
+func (tte *TravelTimeExecutor) stop(ctx context.Context, timedatectlAvailable bool) *spec.Response {
+	// Try to re-enable NTP if timedatectl is available
+	if timedatectlAvailable {
+		response := tte.channel.Run(ctx, "timedatectl", `set-ntp true`)
+		if !response.Success {
+			// Check if the error is due to NTP not being supported
+			if strings.Contains(response.Err, "NTP not supported") {
+				log.Warnf(ctx, "NTP is not supported on this system, skipping NTP re-enable")
+			} else {
+				// For other errors, still return the error
+				return response
+			}
+		}
 	}
+
+	// Sync hardware clock with system time
 	return tte.channel.Run(ctx, "hwclock", `--hctosys`)
 }
 
-func (tte *TravelTimeExecutor) start(ctx context.Context, timeOffsetStr string, disableNtp bool) *spec.Response {
+func (tte *TravelTimeExecutor) start(ctx context.Context, timeOffsetStr string, disableNtp bool, timedatectlAvailable bool) *spec.Response {
 	duration, err := time.ParseDuration(timeOffsetStr)
 	if err != nil {
 		log.Errorf(ctx, "offset is invalid")
 		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "offset", timeOffsetStr, err)
 	}
-	targetTime := time.Now().Add(duration).Format("01/02/2006 15:04:05")
 
-	if disableNtp {
+	// Calculate target time
+	targetTime := time.Now().Add(duration)
+
+	// Try to disable NTP if requested and timedatectl is available
+	if disableNtp && timedatectlAvailable {
 		response := tte.channel.Run(ctx, "timedatectl", `set-ntp false`)
 		if !response.Success {
-			return response
+			// Check if the error is due to NTP not being supported
+			if strings.Contains(response.Err, "NTP not supported") {
+				log.Warnf(ctx, "NTP is not supported on this system, continuing without disabling NTP")
+			} else {
+				// For other errors, still return the error
+				return response
+			}
 		}
 	}
 
-	return tte.channel.Run(ctx, "date", fmt.Sprintf(`-s "%s" `, targetTime))
+	// Set system time using multiple format attempts for better compatibility
+	return tte.setSystemTime(ctx, targetTime)
+}
+
+// setSystemTime attempts to set system time using multiple methods for better compatibility
+func (tte *TravelTimeExecutor) setSystemTime(ctx context.Context, targetTime time.Time) *spec.Response {
+	// Try different time formats for better compatibility
+	timeFormats := []string{
+		"2006-01-02 15:04:05", // ISO format
+		"01/02/2006 15:04:05", // Original format
+		"2006-01-02T15:04:05", // ISO without space
+		"Jan 2 15:04:05 2006", // Unix date format
+	}
+
+	var lastError error
+	for _, format := range timeFormats {
+		timeStr := targetTime.Format(format)
+		log.Infof(ctx, "Attempting to set time with format '%s': %s", format, timeStr)
+
+		response := tte.channel.Run(ctx, "date", fmt.Sprintf(`-s "%s"`, timeStr))
+		if response.Success {
+			log.Infof(ctx, "Successfully set time using format: %s", format)
+			return response
+		}
+		lastError = fmt.Errorf("format %s failed: %s", format, response.Err)
+		log.Warnf(ctx, "Time format '%s' failed: %s", format, response.Err)
+	}
+
+	// If all formats failed, try using timedatectl if available
+	if tte.channel.IsCommandAvailable(ctx, "timedatectl") {
+		isoTime := targetTime.Format("2006-01-02 15:04:05")
+		log.Infof(ctx, "Attempting to set time using timedatectl: %s", isoTime)
+		response := tte.channel.Run(ctx, "timedatectl", fmt.Sprintf(`set-time "%s"`, isoTime))
+		if response.Success {
+			log.Infof(ctx, "Successfully set time using timedatectl")
+			return response
+		}
+		lastError = fmt.Errorf("timedatectl failed: %s", response.Err)
+		log.Warnf(ctx, "timedatectl failed: %s", response.Err)
+	}
+
+	return spec.ResponseFailWithFlags(spec.OsCmdExecFailed,
+		fmt.Sprintf("Failed to set system time with all available methods. Last error: %v", lastError))
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Enhance https://github.com/chaosblade-io/chaosblade/issues/1139


### Describe how you did it
Removed mandatory dependency on timedatectl.
* Previously, both timedatectl and date were required to be available. Now, only the date command is required, making timedatectl optional.
* Intelligent command detection.

Dynamic detection of the availability of timedatectl.
* Selecting the best time modification strategy based on the available commands.
* Multiple time format support.
  * ISO format: 2006-01-02 15:04:05
  * Original format: 01/02/2006 15:04:05
  * ISO without spaces: 2006-01-02T15:04:05
  * Unix format: Jan 2 15:04:05 2006.

Graceful error handling.
* Logs a warning but continues execution when NTP is not supported.
* Provides detailed error information and logging.

Alternative time setting methods.
* Prefers multiple formats of the date command.
* If date fails and timedatectl is available, uses timedatectl set-time instead.

### Describe how to verify it
```
# date
Tue Sep  9 **10:13:37** AM CST 2025

# ./blade c time travel --offset 5m30s --timeout 300
{"code":200,"success":true,"result":"f5b7816d4fed2f0f"}

# date
Tue Sep  9 **10:19:12** AM CST 2025

# ./blade d f5b7816d4fed2f0f
{"code":200,"success":true,"result":{"target":"time","action":"travel","flags":{"offset":"5m30s","timeout":"300"},"ActionProcessHang":false}}

# date
Tue Sep  9 **10:13:51** AM CST 2025
```

### Special notes for reviews
