### PR TITLE
fix: actually support Windows

### DIFF
--- a/exec/model/model_windows.go
+++ b/exec/model/model_windows.go
@@ -1,0 +1,10 @@
+package model
+
+import "github.com/chaosblade-io/chaosblade-spec-go/spec"
+
+// GetAllExpModels returns the experiment model specs in the project.
+// Support for other project about chaosblade
+func GetAllExpModels() []spec.ExpModelCommandSpec {
+	// TODO: implement Windows experiment models
+	return []spec.ExpModelCommandSpec{}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

fix build errors in `chaosblade-exec-middleware` on windows OS: https://github.com/chaosblade-io/chaosblade-exec-middleware/actions/runs/17942833927/job/51023001608?pr=21

### Describe how you did it

Add `model_windows.go`.

### Describe how to verify it


### Special notes for reviews

I need @xcaspar 's help to finish it. I don't know which models are supported on Windows. 