### PR TITLE
fix: improve error handling when killing disk fill processes

### DIFF
--- a/exec/disk/disk_fill.go
+++ b/exec/disk/disk_fill.go
@@ -309,17 +309,21 @@ func stopFill(ctx context.Context, directory string, cl spec.Channel) *spec.Resp
 	}
 	// kill dd or fallocate process
 	pids, _ := cl.GetPidsByProcessName(fillDataFile, ctx)
-	if pids != nil && len(pids) >= 0 {
+	if pids != nil && len(pids) > 0 {
 		resp := cl.Run(ctx, "kill", fmt.Sprintf("-9 %s", strings.Join(pids, " ")))
-		log.Errorf(ctx, "kill fallocate process err: %s", resp.Err)
+		if !resp.Success {
+			log.Errorf(ctx, "kill fallocate process err: %s", resp.Err)
+		}
 	}
 	// kill daemon process
 	// todo
 	// ctx = context.WithValue(ctx, channel.ProcessKey, fillDiskBin)
 	pids, _ = cl.GetPidsByProcessName("disk fill", ctx)
-	if pids != nil && len(pids) >= 0 {
+	if pids != nil && len(pids) > 0 {
 		resp := cl.Run(ctx, "kill", fmt.Sprintf("-9 %s", strings.Join(pids, " ")))
-		log.Errorf(ctx, "kill disk fill daemon process err: %s", resp.Err)
+		if !resp.Success {
+			log.Errorf(ctx, "kill disk fill daemon process err: %s", resp.Err)
+		}
 	}
 	fileName := path.Join(directory, fillDataFile)
 	if exec.CheckFilepathExists(ctx, cl, fileName) {


### PR DESCRIPTION
Updated the logic in `stopFill` to ensure that error messages are logged only when the kill command fails. Additionally, corrected the condition checks for process IDs to ensure they are greater than zero before attempting to kill the processes.


Fix chaosblade-io/chaosblade#1182

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
