### PR TITLE
fix: Use target platform GOOS instead of host platform when generating spec yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ define build_for_platform
 	@GOOS=$(word 1,$(subst _, ,$(1))) GOARCH=$(word 2,$(subst _, ,$(1))) \
 	CGO_ENABLED=0 $(GO) build $(GO_FLAGS) -o $(call get_platform_bin_dir,$(1))/chaos_os main.go
 	@cp extra/strace $(call get_platform_bin_dir,$(1))/ 2>/dev/null || true
-	@GOOS=$(CURRENT_OS) GOARCH=$(CURRENT_ARCH) $(GO) run build/spec.go $(call get_platform_yaml_dir,$(1))/$(OS_YAML_FILE_NAME)
+	@GOOS=$(word 1,$(subst _, ,$(1))) GOARCH=$(word 2,$(subst _, ,$(1))) $(GO) run build/spec.go $(call get_platform_yaml_dir,$(1))/$(OS_YAML_FILE_NAME)
 	@echo "✓ Build completed for $(1)"
 	@echo "  Binary: $(call get_platform_bin_dir,$(1))/chaos_os"
 	@echo "  Version: $(BLADE_VERSION) (commit: $(GIT_COMMIT_SHORT))"


### PR DESCRIPTION
## 问题描述

修复 issue: chaosblade-io/chaosblade#1280

## 问题原因

在 `build_for_platform` 宏中，生成 spec yaml 时使用了编译主机的平台 (`$(CURRENT_OS)`) 而不是目标平台的 GOOS，导致：
- 在 macOS 上交叉编译 Linux ARM64 版本时，生成的 yaml 文件包含的是 Darwin 平台的实验场景（缺少 kernel、systemd、time 等）
- 在 Linux CI 上编译的 release 版本包含完整的 Linux 实验场景

## 修复方案

修改 `build_for_platform` 宏第 78 行，使用目标平台的 GOOS/GOARCH 而不是主机平台：

```diff
- @GOOS=$(CURRENT_OS) GOARCH=$(CURRENT_ARCH) $(GO) run build/spec.go ...
+ @GOOS=$(word 1,$(subst _, ,$(1))) GOARCH=$(word 2,$(subst _, ,$(1))) $(GO) run build/spec.go ...
```

## 影响

- 确保交叉编译时生成的 yaml 文件包含目标平台正确的实验场景
- 不影响在目标平台本地编译的行为