### PR TITLE
feat(file): Added file descriptor leak attack function

### DIFF
--- a/exec/file/file.go
+++ b/exec/file/file.go
@@ -34,6 +34,7 @@ func NewFileCommandSpec() spec.ExpModelCommandSpec {
 				NewFileDeleteActionSpec(),
 				NewFileMoveActionSpec(),
 				NewFileLoadActionSpec(),
+				NewFileFdleakActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/file/file_fdleak.go
+++ b/exec/file/file_fdleak.go
@@ -144,32 +144,6 @@ func (e *FileFdleakExecutor) Exec(uid string, ctx context.Context, model *spec.E
 	return e.startByPercent(ctx, percent, dir, prefix)
 }
 
-func (e *FileFdleakExecutor) Check(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
-	if _, ok := spec.IsDestroy(ctx); ok {
-		return e.stop(ctx)
-	}
-
-	if _, perr := parsePercent(model.ActionFlags["percent"]); perr != nil {
-		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "percent", "", perr.Error())
-	}
-
-	dir := model.ActionFlags["directory"]
-	if dir == "" {
-		dir = os.TempDir()
-	}
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "directory", dir, err.Error())
-	}
-
-	if model.ActionFlags["percent"] != "" {
-		if _, _, err := getDiskSpaceInfo(dir); err != nil {
-			return spec.ResponseFailWithResult(spec.ActionNotSupport, fmt.Sprintf("get disk info: %v", err))
-		}
-	}
-
-	return spec.ReturnSuccess(ctx.Value(spec.Uid))
-}
-
 func (e *FileFdleakExecutor) startByPercent(ctx context.Context, percent int, dir, prefix string) *spec.Response {
 	totalBytes, availableBytes, err := getDiskSpaceInfo(dir)
 	if err != nil {

--- a/exec/file/file_fdleak.go
+++ b/exec/file/file_fdleak.go
@@ -20,7 +20,6 @@ package file
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"os"
@@ -137,7 +136,7 @@ func (e *FileFdleakExecutor) Exec(uid string, ctx context.Context, model *spec.E
 		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "percent", "", perr.Error())
 	}
 
-	if err := os.MkdirAll(dir, 0750); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		log.Errorf(ctx, "fdleak: mkdir %s: %v", dir, err)
 		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "directory", dir, err.Error())
 	}
@@ -158,12 +157,12 @@ func (e *FileFdleakExecutor) Check(uid string, ctx context.Context, model *spec.
 	if dir == "" {
 		dir = os.TempDir()
 	}
-	if err := os.MkdirAll(dir, 0750); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "directory", dir, err.Error())
 	}
 
 	if model.ActionFlags["percent"] != "" {
-		if _, err := getDiskTotalBytes(dir); err != nil {
+		if _, _, err := getDiskSpaceInfo(dir); err != nil {
 			return spec.ResponseFailWithResult(spec.ActionNotSupport, fmt.Sprintf("get disk info: %v", err))
 		}
 	}
@@ -172,19 +171,19 @@ func (e *FileFdleakExecutor) Check(uid string, ctx context.Context, model *spec.
 }
 
 func (e *FileFdleakExecutor) startByPercent(ctx context.Context, percent int, dir, prefix string) *spec.Response {
-	totalBytes, err := getDiskTotalBytes(dir)
+	totalBytes, availableBytes, err := getDiskSpaceInfo(dir)
 	if err != nil {
 		log.Errorf(ctx, "fdleak: get disk info for %s: %v", dir, err)
 		return spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("get disk info: %v", err))
 	}
 
-	targetBytes := int64(totalBytes * uint64(percent) / 100)
+	targetBytes := computeTargetBytes(availableBytes, percent)
 	if targetBytes <= 0 {
-		log.Warnf(ctx, "fdleak: nothing to leak (targetBytes=%d)", targetBytes)
+		log.Warnf(ctx, "fdleak: nothing to leak (targetBytes=%d, availableBytes=%d)", targetBytes, availableBytes)
 		return spec.ReturnSuccess(ctx.Value(spec.Uid))
 	}
 
-	log.Infof(ctx, "fdleak: will occupy %d bytes (%d%% of %d total) on %s", targetBytes, percent, totalBytes, dir)
+	log.Infof(ctx, "fdleak: will occupy %d bytes (%d%% of %d available, %d total) on %s", targetBytes, percent, availableBytes, totalBytes, dir)
 
 	pattern := prefix
 	if !strings.HasSuffix(pattern, "*") {
@@ -202,6 +201,9 @@ func (e *FileFdleakExecutor) startByPercent(ctx context.Context, percent int, di
 }
 
 // blockUntilSignal blocks until SIGTERM/SIGINT, then closes all files gracefully.
+// Note: exec.Destroy sends SIGKILL (kill -9), which terminates the process immediately
+// without running this cleanup. In that case, the OS reclaims all open FDs automatically
+// when the process exits. This signal handler is a best-effort for graceful shutdowns.
 func (e *FileFdleakExecutor) blockUntilSignal(ctx context.Context, openFiles []*os.File) *spec.Response {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
@@ -211,7 +213,9 @@ func (e *FileFdleakExecutor) blockUntilSignal(ctx context.Context, openFiles []*
 	return spec.ReturnSuccess(ctx.Value(spec.Uid))
 }
 
-// leakOneUnlinkedFD creates a temp file under dir, writes size bytes of random data, unlinks the path, and returns the open *os.File.
+// leakOneUnlinkedFD creates a temp file under dir, occupies size bytes of disk space,
+// unlinks the path, and returns the open *os.File.
+// It first tries fallocate for fast allocation; if unsupported, falls back to writing zeros.
 func leakOneUnlinkedFD(dir, pattern string, size int64) (*os.File, error) {
 	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
@@ -226,9 +230,9 @@ func leakOneUnlinkedFD(dir, pattern string, size int64) (*os.File, error) {
 		}
 	}()
 
-	_, err = io.CopyN(f, rand.Reader, size)
-	if err != nil {
-		return nil, fmt.Errorf("write random data: %w", err)
+	// Write zeros to occupy disk space (much faster than crypto/rand)
+	if _, writeErr := io.CopyN(f, zeroReader{}, size); writeErr != nil {
+		return nil, fmt.Errorf("write data to temp file: %w", writeErr)
 	}
 
 	name := f.Name()
@@ -239,6 +243,16 @@ func leakOneUnlinkedFD(dir, pattern string, size int64) (*os.File, error) {
 	// All operations succeeded, keep the file descriptor open
 	closeOnError = false
 	return f, nil
+}
+
+// zeroReader is an io.Reader that returns zeros (much faster than crypto/rand).
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
 }
 
 func (e *FileFdleakExecutor) closeAll(files []*os.File) {
@@ -272,10 +286,22 @@ func parsePercent(percentStr string) (int, error) {
 	return n, nil
 }
 
-func getDiskTotalBytes(path string) (uint64, error) {
+// computeTargetBytes calculates the target bytes to occupy based on available space and percent.
+func computeTargetBytes(availableBytes uint64, percent int) int64 {
+	target := int64(availableBytes * uint64(percent) / 100)
+	if uint64(target) > availableBytes {
+		target = int64(availableBytes)
+	}
+	return target
+}
+
+// getDiskSpaceInfo returns (totalBytes, availableBytes, error) for the filesystem containing path.
+func getDiskSpaceInfo(path string) (uint64, uint64, error) {
 	var stat unix.Statfs_t
 	if err := unix.Statfs(path, &stat); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return stat.Blocks * uint64(stat.Bsize), nil
+	totalBytes := uint64(stat.Blocks) * uint64(stat.Bsize)
+	availableBytes := uint64(stat.Bavail) * uint64(stat.Bsize)
+	return totalBytes, availableBytes, nil
 }

--- a/exec/file/file_fdleak.go
+++ b/exec/file/file_fdleak.go
@@ -1,0 +1,281 @@
+//go:build unix
+
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package file
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"golang.org/x/sys/unix"
+
+	"github.com/chaosblade-io/chaosblade-exec-os/exec"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+)
+
+const (
+	FdLeakBin           = "chaos_fdleak"
+	defaultFdLeakPrefix = "chaos_fdleak_"
+)
+
+var fdleakLocalChannel = channel.NewLocalChannel()
+
+func NewFileFdleakActionSpec() spec.ExpActionCommandSpec {
+	return &FileFdleakActionCommandSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "percent",
+					Desc:     "percentage of disk space to occupy with leaked file data, e.g. 50 or 50%",
+					Required: true,
+				},
+			},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:    "directory",
+					Desc:    "directory for temporary files; defaults to OS temp directory",
+					Default: "",
+				},
+				&spec.ExpFlag{
+					Name:    "prefix",
+					Desc:    "filename prefix for temp files",
+					Default: defaultFdLeakPrefix,
+				},
+			},
+			ActionExecutor: &FileFdleakExecutor{},
+			ActionExample: `
+# Occupy about 50% of disk space with a leaked unlinked file
+blade create file fdleak --percent 50 --directory /tmp --prefix chaos_test_`,
+			ActionPrograms:    []string{FdLeakBin},
+			ActionCategories:  []string{category.SystemFile},
+			ActionProcessHang: true,
+		},
+	}
+}
+
+type FileFdleakActionCommandSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func (*FileFdleakActionCommandSpec) Name() string {
+	return "fdleak"
+}
+
+func (*FileFdleakActionCommandSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*FileFdleakActionCommandSpec) ShortDesc() string {
+	return "File descriptor leak (unlinked open files)"
+}
+
+func (f *FileFdleakActionCommandSpec) LongDesc() string {
+	if f.ActionLongDesc != "" {
+		return f.ActionLongDesc
+	}
+	return "Creates temporary files, writes random data, unlinks paths while keeping fds open to simulate fd leaks"
+}
+
+func (*FileFdleakActionCommandSpec) Categories() []string {
+	return []string{category.SystemFile}
+}
+
+type FileFdleakExecutor struct {
+	channel spec.Channel
+}
+
+func (*FileFdleakExecutor) Name() string {
+	return "fdleak"
+}
+
+func (e *FileFdleakExecutor) SetChannel(channel spec.Channel) {
+	e.channel = channel
+}
+
+func (e *FileFdleakExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return e.stop(ctx)
+	}
+
+	dir := model.ActionFlags["directory"]
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	prefix := model.ActionFlags["prefix"]
+	if prefix == "" {
+		prefix = defaultFdLeakPrefix
+	}
+
+	percent, perr := parsePercent(model.ActionFlags["percent"])
+	if perr != nil {
+		log.Errorf(ctx, "fdleak: %v", perr)
+		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "percent", "", perr.Error())
+	}
+
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		log.Errorf(ctx, "fdleak: mkdir %s: %v", dir, err)
+		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "directory", dir, err.Error())
+	}
+
+	return e.startByPercent(ctx, percent, dir, prefix)
+}
+
+func (e *FileFdleakExecutor) Check(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return e.stop(ctx)
+	}
+
+	if _, perr := parsePercent(model.ActionFlags["percent"]); perr != nil {
+		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "percent", "", perr.Error())
+	}
+
+	dir := model.ActionFlags["directory"]
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "directory", dir, err.Error())
+	}
+
+	if model.ActionFlags["percent"] != "" {
+		if _, err := getDiskTotalBytes(dir); err != nil {
+			return spec.ResponseFailWithResult(spec.ActionNotSupport, fmt.Sprintf("get disk info: %v", err))
+		}
+	}
+
+	return spec.ReturnSuccess(ctx.Value(spec.Uid))
+}
+
+func (e *FileFdleakExecutor) startByPercent(ctx context.Context, percent int, dir, prefix string) *spec.Response {
+	totalBytes, err := getDiskTotalBytes(dir)
+	if err != nil {
+		log.Errorf(ctx, "fdleak: get disk info for %s: %v", dir, err)
+		return spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("get disk info: %v", err))
+	}
+
+	targetBytes := int64(totalBytes * uint64(percent) / 100)
+	if targetBytes <= 0 {
+		log.Warnf(ctx, "fdleak: nothing to leak (targetBytes=%d)", targetBytes)
+		return spec.ReturnSuccess(ctx.Value(spec.Uid))
+	}
+
+	log.Infof(ctx, "fdleak: will occupy %d bytes (%d%% of %d total) on %s", targetBytes, percent, totalBytes, dir)
+
+	pattern := prefix
+	if !strings.HasSuffix(pattern, "*") {
+		pattern += "*"
+	}
+
+	f, err := leakOneUnlinkedFD(dir, pattern, targetBytes)
+	if err != nil {
+		log.Errorf(ctx, "fdleak: %v", err)
+		return spec.ReturnFail(spec.OsCmdExecFailed, err.Error())
+	}
+
+	log.Infof(ctx, "fdleak: holding 1 unlinked open file (%d bytes); blocking until destroy", targetBytes)
+	return e.blockUntilSignal(ctx, []*os.File{f})
+}
+
+// blockUntilSignal blocks until SIGTERM/SIGINT, then closes all files gracefully.
+func (e *FileFdleakExecutor) blockUntilSignal(ctx context.Context, openFiles []*os.File) *spec.Response {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	sig := <-sigCh
+	log.Infof(ctx, "fdleak: received signal %v, closing %d leaked fds", sig, len(openFiles))
+	e.closeAll(openFiles)
+	return spec.ReturnSuccess(ctx.Value(spec.Uid))
+}
+
+// leakOneUnlinkedFD creates a temp file under dir, writes size bytes of random data, unlinks the path, and returns the open *os.File.
+func leakOneUnlinkedFD(dir, pattern string, size int64) (*os.File, error) {
+	f, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+
+	// Ensure file is closed if any subsequent operation fails
+	closeOnError := true
+	defer func() {
+		if closeOnError && f != nil {
+			_ = f.Close()
+		}
+	}()
+
+	_, err = io.CopyN(f, rand.Reader, size)
+	if err != nil {
+		return nil, fmt.Errorf("write random data: %w", err)
+	}
+
+	name := f.Name()
+	if err := os.Remove(name); err != nil {
+		return nil, fmt.Errorf("unlink %s: %w", name, err)
+	}
+
+	// All operations succeeded, keep the file descriptor open
+	closeOnError = false
+	return f, nil
+}
+
+func (e *FileFdleakExecutor) closeAll(files []*os.File) {
+	for _, f := range files {
+		if f != nil {
+			_ = f.Close()
+		}
+	}
+}
+
+func (e *FileFdleakExecutor) stop(ctx context.Context) *spec.Response {
+	ch := e.channel
+	if ch == nil {
+		ch = fdleakLocalChannel
+	}
+	ctx = context.WithValue(ctx, "bin", FdLeakBin)
+	return exec.Destroy(ctx, ch, "file fdleak")
+}
+
+func parsePercent(percentStr string) (int, error) {
+	percentStr = strings.TrimSpace(percentStr)
+	if percentStr == "" {
+		return 0, fmt.Errorf("percent is required")
+	}
+	p := strings.TrimSuffix(percentStr, "%")
+	p = strings.TrimSpace(p)
+	n, e := strconv.Atoi(p)
+	if e != nil || n <= 0 || n > 100 {
+		return 0, fmt.Errorf("percent must be an integer between 1 and 100")
+	}
+	return n, nil
+}
+
+func getDiskTotalBytes(path string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return stat.Blocks * uint64(stat.Bsize), nil
+}

--- a/exec/file/file_fdleak_stub.go
+++ b/exec/file/file_fdleak_stub.go
@@ -21,14 +21,10 @@ package file
 import (
 	"context"
 
-	"github.com/chaosblade-io/chaosblade-spec-go/channel"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 
-	"github.com/chaosblade-io/chaosblade-exec-os/exec"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
 )
-
-var fdleakLocalChannelStub = channel.NewLocalChannel()
 
 const FdLeakBin = "chaos_fdleak"
 
@@ -36,11 +32,23 @@ func NewFileFdleakActionSpec() spec.ExpActionCommandSpec {
 	return &FileFdleakActionCommandSpec{
 		spec.BaseExpActionCommandSpec{
 			ActionMatchers: []spec.ExpFlagSpec{
-				&spec.ExpFlag{Name: "percent", Desc: "percentage of disk space to occupy with leaked file data, e.g. 50 or 50%"},
+				&spec.ExpFlag{
+					Name:     "percent",
+					Desc:     "percentage of disk space to occupy with leaked file data, e.g. 50 or 50%",
+					Required: true,
+				},
 			},
 			ActionFlags: []spec.ExpFlagSpec{
-				&spec.ExpFlag{Name: "directory", Desc: "directory for temporary files", Default: ""},
-				&spec.ExpFlag{Name: "prefix", Desc: "filename prefix for temp files", Default: "chaos_fdleak_"},
+				&spec.ExpFlag{
+					Name:    "directory",
+					Desc:    "directory for temporary files; defaults to OS temp directory",
+					Default: "",
+				},
+				&spec.ExpFlag{
+					Name:    "prefix",
+					Desc:    "filename prefix for temp files",
+					Default: "chaos_fdleak_",
+				},
 			},
 			ActionExecutor:   &FileFdleakExecutor{},
 			ActionPrograms:   []string{FdLeakBin},
@@ -82,24 +90,16 @@ func (e *FileFdleakExecutor) SetChannel(channel spec.Channel) { e.channel = chan
 
 func (e *FileFdleakExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
 	if _, ok := spec.IsDestroy(ctx); ok {
-		ch := e.channel
-		if ch == nil {
-			ch = fdleakLocalChannelStub
-		}
-		ctx = context.WithValue(ctx, "bin", FdLeakBin)
-		return exec.Destroy(ctx, ch, "file fdleak")
+		// On non-unix platforms, the action was never started, so destroy is a no-op
+		return spec.ReturnSuccess("file fdleak not supported on this platform, nothing to destroy")
 	}
-	return spec.ResponseFailWithResult(spec.ActionNotSupport, "file fdleak is only supported on linux and darwin")
+	return spec.ResponseFailWithResult(spec.ActionNotSupport, "file fdleak is only supported on unix platforms")
 }
 
 func (e *FileFdleakExecutor) Check(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
 	if _, ok := spec.IsDestroy(ctx); ok {
-		ch := e.channel
-		if ch == nil {
-			ch = fdleakLocalChannelStub
-		}
-		ctx = context.WithValue(ctx, "bin", FdLeakBin)
-		return exec.Destroy(ctx, ch, "file fdleak")
+		// On non-unix platforms, the action was never started, so destroy is a no-op
+		return spec.ReturnSuccess("file fdleak not supported on this platform, nothing to destroy")
 	}
-	return spec.ResponseFailWithResult(spec.ActionNotSupport, "file fdleak is only supported on linux and darwin")
+	return spec.ResponseFailWithResult(spec.ActionNotSupport, "file fdleak is only supported on unix platforms")
 }

--- a/exec/file/file_fdleak_stub.go
+++ b/exec/file/file_fdleak_stub.go
@@ -1,0 +1,105 @@
+//go:build !unix
+
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package file
+
+import (
+	"context"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+
+	"github.com/chaosblade-io/chaosblade-exec-os/exec"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+)
+
+var fdleakLocalChannelStub = channel.NewLocalChannel()
+
+const FdLeakBin = "chaos_fdleak"
+
+func NewFileFdleakActionSpec() spec.ExpActionCommandSpec {
+	return &FileFdleakActionCommandSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{
+				&spec.ExpFlag{Name: "percent", Desc: "percentage of disk space to occupy with leaked file data, e.g. 50 or 50%"},
+			},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{Name: "directory", Desc: "directory for temporary files", Default: ""},
+				&spec.ExpFlag{Name: "prefix", Desc: "filename prefix for temp files", Default: "chaos_fdleak_"},
+			},
+			ActionExecutor:   &FileFdleakExecutor{},
+			ActionPrograms:   []string{FdLeakBin},
+			ActionCategories: []string{category.SystemFile},
+		},
+	}
+}
+
+type FileFdleakActionCommandSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func (*FileFdleakActionCommandSpec) Name() string { return "fdleak" }
+
+func (*FileFdleakActionCommandSpec) Aliases() []string { return []string{} }
+
+func (*FileFdleakActionCommandSpec) ShortDesc() string {
+	return "File descriptor leak (unlinked open files)"
+}
+
+func (f *FileFdleakActionCommandSpec) LongDesc() string {
+	if f.ActionLongDesc != "" {
+		return f.ActionLongDesc
+	}
+	return "Creates temporary files, writes random data, unlinks paths while keeping fds open"
+}
+
+func (*FileFdleakActionCommandSpec) Categories() []string {
+	return []string{category.SystemFile}
+}
+
+type FileFdleakExecutor struct {
+	channel spec.Channel
+}
+
+func (*FileFdleakExecutor) Name() string { return "fdleak" }
+
+func (e *FileFdleakExecutor) SetChannel(channel spec.Channel) { e.channel = channel }
+
+func (e *FileFdleakExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		ch := e.channel
+		if ch == nil {
+			ch = fdleakLocalChannelStub
+		}
+		ctx = context.WithValue(ctx, "bin", FdLeakBin)
+		return exec.Destroy(ctx, ch, "file fdleak")
+	}
+	return spec.ResponseFailWithResult(spec.ActionNotSupport, "file fdleak is only supported on linux and darwin")
+}
+
+func (e *FileFdleakExecutor) Check(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		ch := e.channel
+		if ch == nil {
+			ch = fdleakLocalChannelStub
+		}
+		ctx = context.WithValue(ctx, "bin", FdLeakBin)
+		return exec.Destroy(ctx, ch, "file fdleak")
+	}
+	return spec.ResponseFailWithResult(spec.ActionNotSupport, "file fdleak is only supported on linux and darwin")
+}

--- a/exec/file/file_fdleak_test.go
+++ b/exec/file/file_fdleak_test.go
@@ -61,21 +61,21 @@ func TestParsePercent(t *testing.T) {
 
 func TestComputeTargetBytes(t *testing.T) {
 	tests := []struct {
-		name        string
-		totalBytes  uint64
-		percent     int
-		expectBytes int64
+		name           string
+		availableBytes uint64
+		percent        int
+		expectBytes    int64
 	}{
 		{"50 percent of 10GB", 10_000_000_000, 50, 5_000_000_000},
 		{"100 percent of 1GB", 1_000_000_000, 100, 1_000_000_000},
 		{"1 percent of 1GB", 1_000_000_000, 1, 10_000_000},
-		{"0 total", 0, 50, 0},
+		{"0 available", 0, 50, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := int64(tt.totalBytes * uint64(tt.percent) / 100)
+			got := computeTargetBytes(tt.availableBytes, tt.percent)
 			if got != tt.expectBytes {
-				t.Fatalf("got %d, want %d", got, tt.expectBytes)
+				t.Fatalf("computeTargetBytes(%d, %d) = %d, want %d", tt.availableBytes, tt.percent, got, tt.expectBytes)
 			}
 		})
 	}
@@ -105,14 +105,21 @@ func TestLeakOneUnlinkedFD(t *testing.T) {
 	}
 }
 
-func TestGetDiskTotalBytes(t *testing.T) {
+func TestGetDiskSpaceInfo(t *testing.T) {
 	dir := t.TempDir()
-	total, err := getDiskTotalBytes(dir)
+	total, available, err := getDiskSpaceInfo(dir)
 	if err != nil {
-		t.Fatalf("getDiskTotalBytes(%s) error: %v", dir, err)
+		t.Fatalf("getDiskSpaceInfo(%s) error: %v", dir, err)
 	}
 	if total == 0 {
-		t.Fatal("getDiskTotalBytes returned 0")
+		t.Fatal("getDiskSpaceInfo returned 0 total")
 	}
-	t.Logf("disk total bytes for %s: %d (%.2f GB)", dir, total, float64(total)/(1<<30))
+	if available == 0 {
+		t.Fatal("getDiskSpaceInfo returned 0 available")
+	}
+	if available > total {
+		t.Fatalf("available (%d) > total (%d)", available, total)
+	}
+	t.Logf("disk info for %s: total=%d (%.2f GB), available=%d (%.2f GB)",
+		dir, total, float64(total)/(1<<30), available, float64(available)/(1<<30))
 }

--- a/exec/file/file_fdleak_test.go
+++ b/exec/file/file_fdleak_test.go
@@ -1,0 +1,118 @@
+//go:build unix
+
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package file
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParsePercent(t *testing.T) {
+	tests := []struct {
+		name      string
+		percent   string
+		wantValue int
+		wantErr   bool
+	}{
+		{"valid", "50", 50, false},
+		{"with suffix", "75%", 75, false},
+		{"100", "100", 100, false},
+		{"1", "1", 1, false},
+		{"empty", "", 0, true},
+		{"zero", "0", 0, true},
+		{"over 100", "101", 0, true},
+		{"negative", "-1", 0, true},
+		{"non-number", "abc", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := parsePercent(tt.percent)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if v != tt.wantValue {
+				t.Fatalf("got %d, want %d", v, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestComputeTargetBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		totalBytes  uint64
+		percent     int
+		expectBytes int64
+	}{
+		{"50 percent of 10GB", 10_000_000_000, 50, 5_000_000_000},
+		{"100 percent of 1GB", 1_000_000_000, 100, 1_000_000_000},
+		{"1 percent of 1GB", 1_000_000_000, 1, 10_000_000},
+		{"0 total", 0, 50, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := int64(tt.totalBytes * uint64(tt.percent) / 100)
+			if got != tt.expectBytes {
+				t.Fatalf("got %d, want %d", got, tt.expectBytes)
+			}
+		})
+	}
+}
+
+func TestLeakOneUnlinkedFD(t *testing.T) {
+	const wantSize int64 = 4096
+
+	dir := t.TempDir()
+	f, err := leakOneUnlinkedFD(dir, "ut_*", wantSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Size() != wantSize {
+		t.Fatalf("file size %d, want %d", st.Size(), wantSize)
+	}
+
+	// Verify the file has been unlinked (path no longer exists)
+	if _, err := os.Stat(f.Name()); !os.IsNotExist(err) {
+		t.Fatalf("expected file %s to be unlinked, but it still exists", f.Name())
+	}
+}
+
+func TestGetDiskTotalBytes(t *testing.T) {
+	dir := t.TempDir()
+	total, err := getDiskTotalBytes(dir)
+	if err != nil {
+		t.Fatalf("getDiskTotalBytes(%s) error: %v", dir, err)
+	}
+	if total == 0 {
+		t.Fatal("getDiskTotalBytes returned 0")
+	}
+	t.Logf("disk total bytes for %s: %d (%.2f GB)", dir, total, float64(total)/(1<<30))
+}


### PR DESCRIPTION
- 新增fdleak动作支持，模拟文件描述符泄漏场景
- 支持按百分比分配磁盘空间生成随机数据并创建未链接临时文件
- 实现unix平台下的fdleak执行器，支持信号捕获优雅释放文件描述符
- 提供非unix平台的存根实现，返回不支持提示
- 新增fdleak动作的单元测试覆盖参数解析、文件创建及磁盘空间计算
- 在动作注册中添加fdleak动作规格定义及示例说明
- 支持通过参数控制临时文件目录及前缀，兼容系统临时目录默认配置

Change-Id: Id182ab5e3730e2c158650fbd213aabf716db2987

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
