### PR TITLE
feat(disk): add unmount-stuck action to simulate volume unmount blocked

### DIFF
--- a/exec/disk/disk.go
+++ b/exec/disk/disk.go
@@ -30,6 +30,7 @@ func NewDiskCommandSpec() spec.ExpModelCommandSpec {
 			ExpActions: []spec.ExpActionCommandSpec{
 				NewFillActionSpec(),
 				NewBurnActionSpec(),
+				NewUnmountStuckActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},
@@ -45,5 +46,5 @@ func (*DiskCommandSpec) ShortDesc() string {
 }
 
 func (*DiskCommandSpec) LongDesc() string {
-	return "Disk experiment contains fill disk or burn io"
+	return "Disk experiment contains fill disk, burn io or unmount stuck"
 }

--- a/exec/disk/disk_unmount_stuck.go
+++ b/exec/disk/disk_unmount_stuck.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path"
+	"runtime"
+	"syscall"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+
+	"github.com/chaosblade-io/chaosblade-exec-os/exec"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+)
+
+const UnmountStuckBin = "chaos_unmountstuck"
+
+var unmountStuckFile = "chaos_unmountstuck.dat"
+
+type UnmountStuckActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewUnmountStuckActionSpec() spec.ExpActionCommandSpec {
+	return &UnmountStuckActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "path",
+					Desc:     "The mount point path to hold file handles on, making umount fail with device busy",
+					Required: true,
+				},
+			},
+			ActionFlags:    []spec.ExpFlagSpec{},
+			ActionExecutor: &UnmountStuckExecutor{},
+			ActionExample: `
+# Simulate volume unmount stuck on /mnt/data
+blade create disk unmount_stuck --path /mnt/data
+
+# Destroy the experiment
+blade destroy disk unmount_stuck --uid <uid>`,
+			ActionPrograms:    []string{UnmountStuckBin},
+			ActionCategories:  []string{category.SystemDisk},
+			ActionProcessHang: true,
+		},
+	}
+}
+
+func (*UnmountStuckActionSpec) Name() string {
+	return "unmount_stuck"
+}
+
+func (*UnmountStuckActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*UnmountStuckActionSpec) ShortDesc() string {
+	return "Simulate volume unmount stuck by holding file handles"
+}
+
+func (u *UnmountStuckActionSpec) LongDesc() string {
+	if u.ActionLongDesc != "" {
+		return u.ActionLongDesc
+	}
+	return "Simulate volume unmount stuck by holding file handles on the specified mount point, making umount fail with device busy"
+}
+
+type UnmountStuckExecutor struct {
+	channel spec.Channel
+}
+
+func (*UnmountStuckExecutor) Name() string {
+	return "unmount_stuck"
+}
+
+func (use *UnmountStuckExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	directory := model.ActionFlags["path"]
+	if directory == "" {
+		log.Errorf(ctx, "path is required")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "path")
+	}
+
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return use.stop(ctx, directory)
+	}
+
+	if !util.IsDir(directory) {
+		log.Errorf(ctx, "`%s`: path is illegal, is not a directory", directory)
+		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "path", directory, "it must be a directory")
+	}
+
+	return use.start(ctx, directory)
+}
+
+func (use *UnmountStuckExecutor) start(ctx context.Context, directory string) *spec.Response {
+	dataFile := path.Join(directory, unmountStuckFile)
+	file, err := os.Create(dataFile)
+	if err != nil {
+		log.Errorf(ctx, "failed to create sentinel file %s: %v", dataFile, err)
+		return spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("failed to create sentinel file: %v", err))
+	}
+	// Hold the file handle open, do NOT close it during normal execution.
+	// This prevents umount from succeeding on this mount point.
+	log.Infof(ctx, "holding file handle on %s, umount will be blocked", directory)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	<-sigCh
+	signal.Stop(sigCh)
+	// Ensure the file is not garbage collected before the signal is received.
+	runtime.KeepAlive(file)
+
+	// Best-effort cleanup on graceful shutdown
+	if err := file.Close(); err != nil {
+		log.Errorf(ctx, "failed to close sentinel file %s on shutdown: %v", dataFile, err)
+	}
+	if err := os.Remove(dataFile); err != nil && !os.IsNotExist(err) {
+		log.Errorf(ctx, "failed to remove sentinel file %s on shutdown: %v", dataFile, err)
+	}
+	return spec.ReturnSuccess(directory)
+}
+
+func (use *UnmountStuckExecutor) stop(ctx context.Context, directory string) *spec.Response {
+	// Clean up sentinel file using Go native API to avoid command injection
+	dataFile := path.Join(directory, unmountStuckFile)
+	if _, err := os.Stat(dataFile); err == nil {
+		if err := os.Remove(dataFile); err != nil && !os.IsNotExist(err) {
+			log.Errorf(ctx, "failed to clean sentinel file %s: %v", dataFile, err)
+		}
+	}
+
+	ctx = context.WithValue(ctx, "bin", UnmountStuckBin)
+	return exec.Destroy(ctx, use.channel, "disk unmount_stuck")
+}
+
+func (use *UnmountStuckExecutor) SetChannel(channel spec.Channel) {
+	use.channel = channel
+}

--- a/exec/disk/disk_unmount_stuck_test.go
+++ b/exec/disk/disk_unmount_stuck_test.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+import (
+	"context"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+)
+
+func TestUnmountStuckActionSpec(t *testing.T) {
+	s := NewUnmountStuckActionSpec()
+	if s.Name() != "unmount_stuck" {
+		t.Fatalf("expected name unmount_stuck, got %s", s.Name())
+	}
+	if s.ShortDesc() == "" {
+		t.Fatal("ShortDesc should not be empty")
+	}
+	if s.LongDesc() == "" {
+		t.Fatal("LongDesc should not be empty")
+	}
+	if s.Executor() == nil {
+		t.Fatal("Executor should not be nil")
+	}
+	if len(s.Programs()) == 0 {
+		t.Fatal("Programs should not be empty")
+	}
+	if s.Programs()[0] != UnmountStuckBin {
+		t.Fatalf("expected program %s, got %s", UnmountStuckBin, s.Programs()[0])
+	}
+}
+
+func TestUnmountStuckExec_MissingPath(t *testing.T) {
+	executor := &UnmountStuckExecutor{}
+	executor.SetChannel(channel.NewLocalChannel())
+
+	ctx := context.Background()
+	model := &spec.ExpModel{
+		ActionFlags: map[string]string{},
+	}
+	resp := executor.Exec("test-uid", ctx, model)
+	if resp.Success {
+		t.Fatal("expected failure when path is missing")
+	}
+}
+
+func TestUnmountStuckExec_InvalidPath(t *testing.T) {
+	executor := &UnmountStuckExecutor{}
+	executor.SetChannel(channel.NewLocalChannel())
+
+	ctx := context.Background()
+	model := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			"path": "/nonexistent_path_for_test_12345",
+		},
+	}
+	resp := executor.Exec("test-uid", ctx, model)
+	if resp.Success {
+		t.Fatal("expected failure when path is not a directory")
+	}
+}
+
+func TestUnmountStuckStart_CreatesSentinelFile(t *testing.T) {
+	dir := t.TempDir()
+	executor := &UnmountStuckExecutor{}
+	executor.SetChannel(channel.NewLocalChannel())
+
+	ctx := context.Background()
+
+	// Run start in a goroutine since it blocks on signal
+	done := make(chan *spec.Response, 1)
+	go func() {
+		done <- executor.start(ctx, dir)
+	}()
+
+	// Wait for sentinel file to be created
+	sentinelPath := path.Join(dir, unmountStuckFile)
+	deadline := time.After(3 * time.Second)
+	for {
+		if _, err := os.Stat(sentinelPath); err == nil {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("sentinel file was not created within timeout")
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	// Send SIGTERM to unblock the start method
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+
+	select {
+	case resp := <-done:
+		if !resp.Success {
+			t.Fatalf("expected success response, got: %s", resp.Err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("start did not return after SIGTERM")
+	}
+
+	// After graceful shutdown, sentinel file should be cleaned up
+	if _, err := os.Stat(sentinelPath); !os.IsNotExist(err) {
+		t.Fatal("sentinel file should be removed after graceful shutdown")
+	}
+}
+
+func TestUnmountStuckStop_CleansSentinelFile(t *testing.T) {
+	dir := t.TempDir()
+	executor := &UnmountStuckExecutor{}
+	executor.SetChannel(channel.NewLocalChannel())
+
+	// Create sentinel file manually
+	sentinelPath := path.Join(dir, unmountStuckFile)
+	f, err := os.Create(sentinelPath)
+	if err != nil {
+		t.Fatalf("failed to create sentinel file: %v", err)
+	}
+	f.Close()
+
+	// Verify it exists
+	if _, err := os.Stat(sentinelPath); err != nil {
+		t.Fatalf("sentinel file should exist: %v", err)
+	}
+
+	ctx := context.Background()
+	ctx = spec.SetDestroyFlag(ctx, "test-uid")
+	executor.stop(ctx, dir)
+
+	// Verify sentinel file is removed
+	if _, err := os.Stat(sentinelPath); !os.IsNotExist(err) {
+		t.Fatal("sentinel file should be removed after stop")
+	}
+}
+
+func TestUnmountStuckStop_NoFileNoPanic(t *testing.T) {
+	dir := t.TempDir()
+	executor := &UnmountStuckExecutor{}
+	executor.SetChannel(channel.NewLocalChannel())
+
+	ctx := context.Background()
+	ctx = spec.SetDestroyFlag(ctx, "test-uid")
+
+	// Should not panic when sentinel file doesn't exist
+	resp := executor.stop(ctx, dir)
+	if !resp.Success {
+		// exec.Destroy may return success with "no processes found"
+		t.Logf("stop response: %v", resp)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new `disk unmount-stuck` action that holds file handles on a specified mount point, causing `umount` to fail with "device busy"
- This simulates real-world scenarios where volume unmount operations get stuck due to open file descriptors
- Usage: `blade create disk unmount-stuck --path /mnt/data`

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go vet ./...` passes
- [x] `go test ./exec/disk/...` passes
- [x] Manual test: create experiment -> umount returns "Resource busy" -> destroy experiment -> umount succeeds

	🤖 Generated with [Qoder][https://qoder.com]