### PR TITLE
Added file fdleak fault injection action

### DIFF
--- a/exec/file/file_fallocate_linux.go
+++ b/exec/file/file_fallocate_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package file
+
+import "syscall"
+
+// tryFallocate attempts to use the Linux fallocate syscall for instant disk space allocation.
+func tryFallocate(fd int, size int64) error {
+	return syscall.Fallocate(fd, 0, 0, size)
+}

--- a/exec/file/file_fallocate_other.go
+++ b/exec/file/file_fallocate_other.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package file
+
+import "errors"
+
+// tryFallocate is a no-op on non-Linux platforms; the caller should fall back to writing zeros.
+func tryFallocate(fd int, size int64) error {
+	return errors.New("fallocate not supported on this platform")
+}

--- a/exec/file/file_fdleak.go
+++ b/exec/file/file_fdleak.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -117,10 +118,6 @@ func (e *FileFdleakExecutor) SetChannel(channel spec.Channel) {
 }
 
 func (e *FileFdleakExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
-	if _, ok := spec.IsDestroy(ctx); ok {
-		return e.stop(ctx)
-	}
-
 	dir := model.ActionFlags["directory"]
 	if dir == "" {
 		dir = os.TempDir()
@@ -128,6 +125,10 @@ func (e *FileFdleakExecutor) Exec(uid string, ctx context.Context, model *spec.E
 	prefix := model.ActionFlags["prefix"]
 	if prefix == "" {
 		prefix = defaultFdLeakPrefix
+	}
+
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return e.stop(ctx, dir, prefix)
 	}
 
 	percent, perr := parsePercent(model.ActionFlags["percent"])
@@ -190,6 +191,9 @@ func (e *FileFdleakExecutor) blockUntilSignal(ctx context.Context, openFiles []*
 // leakOneUnlinkedFD creates a temp file under dir, occupies size bytes of disk space,
 // unlinks the path, and returns the open *os.File.
 // It first tries fallocate for fast allocation; if unsupported, falls back to writing zeros.
+// The file path is unlinked immediately after creation (before writing data), so that
+// even if the process is killed (SIGKILL) during the write, the OS will automatically
+// reclaim disk space when the fd is closed — no residual files left on disk.
 func leakOneUnlinkedFD(dir, pattern string, size int64) (*os.File, error) {
 	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
@@ -204,14 +208,20 @@ func leakOneUnlinkedFD(dir, pattern string, size int64) (*os.File, error) {
 		}
 	}()
 
-	// Write zeros to occupy disk space (much faster than crypto/rand)
-	if _, writeErr := io.CopyN(f, zeroReader{}, size); writeErr != nil {
-		return nil, fmt.Errorf("write data to temp file: %w", writeErr)
-	}
-
+	// Unlink the file path first, before writing any data.
+	// This ensures that if the process is killed during write, the OS reclaims
+	// disk space automatically when the fd is closed — no orphan files remain.
 	name := f.Name()
 	if err := os.Remove(name); err != nil {
 		return nil, fmt.Errorf("unlink %s: %w", name, err)
+	}
+
+	// Try fallocate first (instant disk space allocation without writing data)
+	if fallocErr := tryFallocate(int(f.Fd()), size); fallocErr != nil {
+		// Fallocate not supported (e.g., tmpfs, some filesystems), fall back to writing zeros
+		if _, writeErr := io.CopyN(f, zeroReader{}, size); writeErr != nil {
+			return nil, fmt.Errorf("write data to temp file: %w", writeErr)
+		}
 	}
 
 	// All operations succeeded, keep the file descriptor open
@@ -237,13 +247,37 @@ func (e *FileFdleakExecutor) closeAll(files []*os.File) {
 	}
 }
 
-func (e *FileFdleakExecutor) stop(ctx context.Context) *spec.Response {
+func (e *FileFdleakExecutor) stop(ctx context.Context, dir, prefix string) *spec.Response {
 	ch := e.channel
 	if ch == nil {
 		ch = fdleakLocalChannel
 	}
 	ctx = context.WithValue(ctx, "bin", FdLeakBin)
-	return exec.Destroy(ctx, ch, "file fdleak")
+	resp := exec.Destroy(ctx, ch, "file fdleak")
+
+	// Best-effort cleanup: after killing the process, try to remove any leftover
+	// temp files. On normal filesystems this works reliably. On overlay FS, files
+	// may be hidden by whiteouts and not found by Glob — this is a known limitation.
+	e.cleanupTempFiles(ctx, dir, prefix)
+
+	return resp
+}
+
+// cleanupTempFiles removes temp files matching the prefix pattern in the given directory.
+func (e *FileFdleakExecutor) cleanupTempFiles(ctx context.Context, dir, prefix string) {
+	pattern := filepath.Join(dir, prefix+"*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		log.Warnf(ctx, "fdleak cleanup: glob %s: %v", pattern, err)
+		return
+	}
+	for _, path := range matches {
+		if err := os.Remove(path); err != nil {
+			log.Warnf(ctx, "fdleak cleanup: remove %s: %v", path, err)
+		} else {
+			log.Infof(ctx, "fdleak cleanup: removed %s", path)
+		}
+	}
 }
 
 func parsePercent(percentStr string) (int, error) {

--- a/exec/file/file_fdleak.go
+++ b/exec/file/file_fdleak.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -295,12 +296,19 @@ func parsePercent(percentStr string) (int, error) {
 }
 
 // computeTargetBytes calculates the target bytes to occupy based on available space and percent.
+// It performs arithmetic in uint64 to avoid overflow on very large filesystems, then clamps
+// the result to math.MaxInt64 before converting to int64.
 func computeTargetBytes(availableBytes uint64, percent int) int64 {
-	target := int64(availableBytes * uint64(percent) / 100)
-	if uint64(target) > availableBytes {
-		target = int64(availableBytes)
+	// Use division-first to avoid uint64 overflow: availableBytes / 100 * percent
+	// loses at most (percent-1) bytes of precision, which is negligible.
+	target := availableBytes / 100 * uint64(percent)
+	if target > availableBytes {
+		target = availableBytes
 	}
-	return target
+	if target > uint64(math.MaxInt64) {
+		target = uint64(math.MaxInt64)
+	}
+	return int64(target)
 }
 
 // getDiskSpaceInfo returns (totalBytes, availableBytes, error) for the filesystem containing path.

--- a/exec/file/file_fdleak_stub.go
+++ b/exec/file/file_fdleak_stub.go
@@ -73,7 +73,7 @@ func (f *FileFdleakActionCommandSpec) LongDesc() string {
 	if f.ActionLongDesc != "" {
 		return f.ActionLongDesc
 	}
-	return "Creates temporary files, writes random data, unlinks paths while keeping fds open"
+	return "Creates temporary files, writes data, unlinks paths while keeping fds open"
 }
 
 func (*FileFdleakActionCommandSpec) Categories() []string {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
新增 file fdleak 故障注入动作，模拟文件描述符泄漏场景：通过创建临时文件并 unlink 路径后保持 fd 打开，占用指定比例的磁盘空间。同时支持 fallocate 快速分配和 destroy 时的兜底清理。

### Does this pull request fix one issue?
NONE

### Describe how you did it
- 实现 leakOneUnlinkedFD：创建临时文件 → unlink 路径 → 通过 fd 写入数据，模拟真实 fd 泄漏
- 支持 --percent 参数按磁盘可用空间百分比填充
- Linux 平台优先使用 syscall.Fallocate 快速分配空间，不支持时回退到写零
- 进程通过信号等待阻塞，收到 SIGTERM/SIGINT 后主动关闭 fd
- destroy 时先 kill 进程，再通过 cleanupTempFiles 按 glob 模式清理残留文件作为兜底

### Describe how to verify it
- 部署 operator 并下发 CR（target: file, action: fdleak, percent: 50, directory: /tmp）
- 验证 df -h 磁盘占用增加约 50%，ls /tmp 无可见文件，/proc/PID/fd 显示 (deleted)
- 删除 CR 后确认磁盘恢复至基线水平

### Special notes for reviews
- file_fallocate_linux.go / file_fallocate_other.go 通过 //go:build 实现平台隔离，避免非 Linux 平台编译报错
- overlay FS 上对 upperdir-only 文件的 os.Remove 是真正的 unlink，进程退出后空间可正常回收
- cleanupTempFiles 是尽力清理，在 overlay whiteout 场景下可能无法找到文件，但不影响正常回收流程