### PR TITLE
Fix chaosblade-io/chaosblade#1131: add --climb-time examples to cpu load help

### DIFF
--- a/exec/cpu/cpu.go
+++ b/exec/cpu/cpu.go
@@ -69,7 +69,13 @@ blade create cpu load --cpu-list 0,3
 blade create cpu load --cpu-list 1-3
 
 # Specified percentage load
-blade create cpu load --cpu-percent 60`,
+blade create cpu load --cpu-percent 60
+
+# Gradually increase CPU load to 60% over 30 seconds
+blade create cpu load --cpu-percent 60 --climb-time 30
+
+# Gradually increase CPU load on 2 cores to 80% over 60 seconds
+blade create cpu load --cpu-percent 80 --cpu-count 2 --climb-time 60`,
 						ActionPrograms:    []string{BurnCpuBin},
 						ActionCategories:  []string{category.SystemCpu},
 						ActionProcessHang: true,


### PR DESCRIPTION
## Summary
Fixes chaosblade-io/chaosblade#1131

The `--climb-time` parameter for `blade create cpu load` is implemented but missing from the help examples. This PR adds two practical examples demonstrating gradual CPU load increase.

## Changes
- Added example: gradual single-core load increase (`--cpu-percent 60 --climb-time 30`)
- Added example: gradual multi-core load increase (`--cpu-percent 80 --cpu-count 2 --climb-time 60`)

## File Modified
- `exec/cpu/cpu.go` — Updated `ActionExample` field

## Testing
- `blade create cpu load -h` will show the new examples
- No functional code changes, only documentation string update

---
*Automated PR by github-manager-bot*